### PR TITLE
fix: 修复 Star History 图表无法显示的问题

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -616,5 +616,5 @@ MIT License
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=katelya77/K-Vault&type=Date)](https://star-history.com/#katelya77/K-Vault&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=katelya77/K-Vault&type=Date)](https://star-history.dera.page/#katelya77/K-Vault&Date)
 

--- a/README.md
+++ b/README.md
@@ -839,4 +839,4 @@ MIT License
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=katelya77/K-Vault&type=Date)](https://star-history.com/#katelya77/K-Vault&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=katelya77/K-Vault&type=Date)](https://star-history.dera.page/#katelya77/K-Vault&Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标接口限制已失效，无法正常显示。此 PR 将图表地址切换为可用的新服务，恢复仓库 Star 历史图表的展示。