### PR TITLE
fix(api-token): 平台化重构 API Token（安全/策略/幂等/SSRF/Agent 接入）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,9 @@ GITHUB_PREFIX=
 GITHUB_RELEASE_TAG=
 GITHUB_BRANCH=
 GITHUB_API_BASE=https://api.github.com
+
+# API v1 CORS allow-list for browser clients (server-to-server agents need none)
+# Comma-separated origins; trailing slashes are normalized. Leave empty to send
+# no CORS headers at all. Example:
+# API_CORS_ORIGINS=https://app.example.com,https://dashboard.example.com
+API_CORS_ORIGINS=

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
     - name: Install dependencies
       run: npm install
     - name: Run tests

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -44,7 +44,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p .artifacts
-          docker compose exec -T k-vault sh -lc "wget -qO- http://localhost:8080/api/status" > .artifacts/api-status.json || true
+          docker compose exec -T k-vault sh -lc "wget -qO- http://127.0.0.1:8080/api/status" > .artifacts/api-status.json || true
           docker compose exec -T k-vault sh -lc "cd /app/server && node -e \"const { createContainer }=require('./lib/container'); const c=createContainer(process.env); console.log(JSON.stringify(c.storageRepo.list(false).map(x=>({id:x.id,type:x.type,name:x.name,enabled:x.enabled,isDefault:x.isDefault})), null, 2));\"" > .artifacts/storage-profiles.json || true
 
       - name: Show runtime logs on failure

--- a/README.md
+++ b/README.md
@@ -840,3 +840,68 @@ MIT License
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=katelya77/K-Vault&type=Date)](https://star-history.com/#katelya77/K-Vault&Date)
+
+---
+
+## API Token：机器凭据与 Agent 接入
+
+K-Vault 内置面向机器客户端（GitHub Actions、Coze Agent、ShareX、自动化脚本、未来 MCP Agent）的长期 API Token 体系，与网页登录态完全隔离。完整接入指南见 [docs/agent-integration.md](docs/agent-integration.md)，机器可读接口定义见 [docs/openapi.yaml](docs/openapi.yaml)。
+
+### 创建 Token
+
+- **网页**：登录管理后台 →「API Token 管理」→ 新建，可设置名称、scopes、过期时间与策略。
+- **Admin API**（未配置 `BASIC_USER`/`BASIC_PASS` 时 admin API fail-closed，返回 503）：
+
+```bash
+curl -X POST "https://your-kvault-domain/api/admin/tokens" \
+  -u "$BASIC_USER:$BASIC_PASS" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"blog-bot","scopes":["upload","read"],"policies":{"folderPrefix":"blog"}}'
+```
+
+响应中的 `token` 字段即完整密钥（`kvault_<id>_<secret>`），仅此一次返回，请立即妥善保存。轮换（rotate）后旧密钥立即失效。
+
+### Scopes 与策略
+
+| Scope | 能力 |
+| --- | --- |
+| `upload` | 上传文件 / URL 导入 |
+| `read` | 列出与读取文件 |
+| `delete` | 删除文件 |
+| `paste` | 创建 Paste |
+
+可选策略：`allowedStorages`（限定存储后端）、`folderPrefix`（限定目录前缀）、`maxFileSize`（单文件上限，界面按 MB 填写）。违规返回 403 `POLICY_DENIED` / 413 `POLICY_FILE_TOO_LARGE`。
+
+### 调用示例
+
+```bash
+# 上传文件（≤25MB 重复内容自动去重）
+curl -X POST "https://your-kvault-domain/api/v1/upload" \
+  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -H "Idempotency-Key: post-42-cover" \
+  -F "file=@./photo.png" -F "storage=telegram" -F "folderPath=blog/2026"
+
+# 远程 URL 导入（内置 SSRF 防护）
+curl -X POST "https://your-kvault-domain/api/v1/import" \
+  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://cdn.example.com/cover.jpg","storage":"r2"}'
+
+# 列出 / 查询 / 删除
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/files?limit=50"
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/file/<id>/info"
+curl -X DELETE -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/file/<id>"
+```
+
+重复携带同一 `Idempotency-Key` 的上传/导入会在 24 小时内返回首次响应（响应头 `Idempotency-Replayed: true`）。
+
+### 跨域配置：API_CORS_ORIGINS
+
+浏览器直连 API 的前端需要显式跨域白名单（服务端环境变量）：
+
+```
+API_CORS_ORIGINS=https://app.example.com,https://dashboard.example.com
+```
+
+- 逗号分隔，末尾斜杠自动归一化；未配置时不返回任何 CORS 头，纯服务端调用不受影响。
+- 预检（OPTIONS）仅放行白名单来源，允许 `Authorization`、`Content-Type`、`Idempotency-Key` 请求头。

--- a/admin.html
+++ b/admin.html
@@ -1561,6 +1561,7 @@
       title="API Token 管理"
       :visible.sync="tokenDialogVisible"
       width="860px"
+      append-to-body
       custom-class="token-manager-dialog">
       <div class="token-toolbar">
         <el-button size="mini" type="primary" icon="el-icon-plus" @click="openCreateTokenDialog">新建 Token</el-button>
@@ -1624,8 +1625,15 @@
             </span>
           </template>
         </el-table-column>
-        <el-table-column label="操作" width="86" align="center">
+        <el-table-column label="操作" width="140" align="center">
           <template slot-scope="scope">
+            <el-button
+              type="text"
+              style="color:#e6a23c"
+              :disabled="Boolean(tokenMutatingMap[scope.row.id])"
+              @click="rotateApiToken(scope.row)">
+              轮换
+            </el-button>
             <el-button
               type="text"
               style="color:#f56c6c"
@@ -1636,6 +1644,19 @@
           </template>
         </el-table-column>
       </el-table>
+      <div style="margin-top:14px;padding:10px 12px;background:#f5f7fa;border-radius:6px;border:1px solid #ebeef5;">
+        <div style="font-size:13px;font-weight:600;color:#606266;margin-bottom:6px;"><i class="fas fa-terminal"></i> 脚本 / Agent 调用示例</div>
+        <pre style="margin:0;font-size:12px;line-height:1.7;color:#476582;background:#fafbfc;border-radius:4px;padding:10px;overflow-x:auto;"># curl 上传（storage 可选 telegram/r2/s3/discord/huggingface/webdav/github）
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -F "file=@./image.png" -F "storage=r2" \
+  {SITE_URL}/api/v1/upload
+
+# 从 URL 导入图片
+curl -X POST "{SITE_URL}/api/v1/import" \
+  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/cat.jpg","storage":"r2"}'</pre>
+      </div>
     </el-dialog>
 
     <el-dialog
@@ -1655,6 +1676,17 @@
             <el-checkbox label="delete"><i class="fas fa-trash-alt"></i> 删除文件/粘贴</el-checkbox>
             <el-checkbox label="paste"><i class="fas fa-file-alt"></i> 创建文本粘贴</el-checkbox>
           </el-checkbox-group>
+        </el-form-item>
+        <el-form-item label="存储限制（可选，留空不限制）">
+          <el-select v-model="tokenForm.allowedStorages" multiple clearable placeholder="允许使用的存储后端" style="width:100%;">
+            <el-option v-for="s in storageOptions" :key="s" :label="s" :value="s"></el-option>
+          </el-select>
+        </el-form-item>
+        <el-form-item label="目录前缀（可选）">
+          <el-input v-model="tokenForm.folderPrefix" maxlength="120" placeholder="例如：agent-uploads，Token 只能写入该目录"></el-input>
+        </el-form-item>
+        <el-form-item label="单文件大小上限（可选，MB）">
+          <el-input-number v-model="tokenForm.maxFileSizeMb" :min="0" :max="1024" :step="5" style="width:100%;"></el-input-number>
         </el-form-item>
         <el-form-item label="过期时间">
           <el-select v-model="tokenForm.expiryPreset" placeholder="请选择过期策略" style="width:100%;">
@@ -1961,7 +1993,11 @@
         scopes: ['upload', 'read'],
         expiryPreset: 'never',
         customExpiresAt: '',
+        allowedStorages: [],
+        folderPrefix: '',
+        maxFileSizeMb: 0,
       },
+      storageOptions: ['telegram', 'r2', 's3', 'discord', 'huggingface', 'webdav', 'github'],
       moveDialogVisible: false,
       moveDialogLoading: false,
       moveDialogFoldersLoading: false,
@@ -2243,6 +2279,9 @@
           scopes: ['upload', 'read'],
           expiryPreset: 'never',
           customExpiresAt: '',
+          allowedStorages: [],
+          folderPrefix: '',
+          maxFileSizeMb: 0,
         };
         this.createTokenDialogVisible = true;
       },
@@ -2301,6 +2340,7 @@
               name,
               scopes,
               expiresAt,
+              policies: this.buildTokenPolicies(),
             }),
           });
           const payload = await response.json();
@@ -2384,6 +2424,50 @@
           this.$message.success('Token 已删除。');
         } catch (error) {
           this.$message.error(error.message || '删除 Token 失败。');
+        } finally {
+          this.$delete(this.tokenMutatingMap, tokenId);
+        }
+      },
+      buildTokenPolicies() {
+        const policies = {};
+        const storages = Array.isArray(this.tokenForm.allowedStorages)
+          ? this.tokenForm.allowedStorages.filter(Boolean)
+          : [];
+        if (storages.length > 0) policies.allowedStorages = storages;
+        const folderPrefix = String(this.tokenForm.folderPrefix || '').trim();
+        if (folderPrefix) policies.folderPrefix = folderPrefix;
+        const maxMb = Number(this.tokenForm.maxFileSizeMb || 0);
+        if (Number.isFinite(maxMb) && maxMb > 0) policies.maxFileSize = Math.round(maxMb * 1024 * 1024);
+        return Object.keys(policies).length > 0 ? policies : null;
+      },
+      async rotateApiToken(token) {
+        const tokenId = token?.id;
+        if (!tokenId) return;
+        try {
+          await this.$confirm(
+            `确认轮换 Token「${token.name}」吗？旧 Secret 将立即失效，新 Secret 只展示一次。`,
+            '轮换确认',
+            { type: 'warning', confirmButtonText: '轮换', cancelButtonText: '取消' }
+          );
+        } catch {
+          return;
+        }
+        this.$set(this.tokenMutatingMap, tokenId, true);
+        try {
+          const response = await fetch(`./api/admin/tokens/${encodeURIComponent(tokenId)}/rotate`, {
+            method: 'POST',
+            credentials: 'include',
+          });
+          const payload = await response.json();
+          if (!response.ok || !payload?.success) {
+            throw new Error(payload?.error?.message || payload?.message || '轮换 Token 失败。');
+          }
+          this.createdTokenValue = String(payload.token || '');
+          this.createdTokenCopied = false;
+          this.createdTokenDialogVisible = true;
+          await this.loadApiTokens();
+        } catch (error) {
+          this.$message.error(error.message || '轮换 Token 失败。');
         } finally {
           this.$delete(this.tokenMutatingMap, tokenId);
         }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 8080;
+  listen [::]:8080;
   server_name _;
   root /usr/share/nginx/html;
   index index.html;

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,159 @@
+# K-Vault Agent 接入指南（API Token / MCP Tools）
+
+面向机器客户端 —— MCP Agent、GitHub Actions、Coze Workflow、ShareX、自动化脚本 —— 的 K-Vault 图床接入说明。机器可读接口定义见 [openapi.yaml](./openapi.yaml)。
+
+所有示例中的 `https://your-kvault-domain` 替换为你的部署地址；`$KVAULT_API_TOKEN` 为 Token 明文（形如 `kvault_<id>_<secret>`），仅创建/轮换时返回一次，切勿写入仓库、日志或截图。
+
+## 1. 准备 Token
+
+### 方式 A：管理后台
+
+登录 → 「API Token 管理」→ 新建：填写名称、勾选 scopes、可选过期时间与策略（allowedStorages / folderPrefix / maxFileSize，界面按 MB 填写大小）。明文仅创建时展示一次。
+
+### 方式 B：Admin API（Basic 认证）
+
+```bash
+curl -X POST "https://your-kvault-domain/api/admin/tokens" \
+  -u "$BASIC_USER:$BASIC_PASS" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"blog-bot","scopes":["upload","read"],"expiresAtMs":1790000000000,"policies":{"folderPrefix":"blog"}}'
+```
+
+> 未配置 `BASIC_USER` / `BASIC_PASS` 时 admin API 整体 fail-closed，返回 503 `ADMIN_AUTH_NOT_CONFIGURED`。
+
+### Scopes
+
+| Scope | 能力 |
+| --- | --- |
+| `upload` | `POST /api/v1/upload`、`POST /api/v1/import` |
+| `read` | `GET /api/v1/files`、`GET /api/v1/file/:id`、`GET /api/v1/file/:id/info` |
+| `delete` | `DELETE /api/v1/file/:id` |
+| `paste` | Paste 相关端点 |
+
+### 策略（policies，可选）
+
+创建/更新时传入，服务端对每次请求强制执行：
+
+| 字段 | 说明 | 违规返回 |
+| --- | --- | --- |
+| `allowedStorages` | 限定存储后端（telegram / r2 / s3 / discord / huggingface / webdav / github） | 403 `POLICY_DENIED` |
+| `folderPrefix` | 限定目录前缀 | 403 `POLICY_DENIED` |
+| `maxFileSize` | 单文件字节上限（管理界面按 MB 输入，自动换算） | 413 `POLICY_FILE_TOO_LARGE` |
+
+## 2. 鉴权与通用约定
+
+- 除 `GET /api/v1/capabilities` 外，所有 v1 端点需要 `Authorization: Bearer $KVAULT_API_TOKEN`。
+- 成功响应：`{"success": true, ...}`；失败：`{"success": false, "error": {"code": "...", "message": "...", "detail": "..."}}`。
+- 常见错误码：
+  - 401 `TOKEN_MISSING` / `TOKEN_INVALID` / `TOKEN_EXPIRED` / `TOKEN_DISABLED`
+  - 403 `SCOPE_REQUIRED` / `POLICY_DENIED`
+  - 413 `FILE_TOO_LARGE` / `POLICY_FILE_TOO_LARGE`
+  - 触发令牌级限流返回 429
+- 幂等：请求头 `Idempotency-Key`（≤200 字符）。同一 Token + 同一 Key 在 24 小时内重放首次成功响应，响应头带 `Idempotency-Replayed: true`。上传与导入均支持。
+
+## 3. MCP Tools 对照表（7 个）
+
+| Tool | HTTP | 说明 |
+| --- | --- | --- |
+| `kvault_health` | GET /api/v1/capabilities | 存活/就绪探测（200 且 `data.apiVersion` 存在即健康） |
+| `kvault_capabilities` | GET /api/v1/capabilities | 能力清单：可用存储后端、大小上限、图片类型 |
+| `kvault_token_info` | GET /api/v1/me | 当前 Token 的 scopes / policies / 用量 |
+| `kvault_upload_file` | POST /api/v1/upload | multipart 文件上传 |
+| `kvault_import_url` | POST /api/v1/import | 远程 URL 导入（内置 SSRF 防护） |
+| `kvault_list_files` | GET /api/v1/files | 游标分页列表 |
+| `kvault_get_file` | GET /api/v1/file/:id/info；GET /api/v1/file/:id | 元信息 JSON / 字节流（支持 Range） |
+
+### 3.1 kvault_health / kvault_capabilities
+
+```bash
+curl "https://your-kvault-domain/api/v1/capabilities"
+```
+
+```json
+{"success":true,"data":{"apiVersion":"v1","upload":true,"importFromUrl":true,"maxUploadSize":104857600,"storages":["telegram","r2"],"imageTypes":["image/jpeg","image/png","image/webp","image/avif","image/gif","image/bmp"]}}
+```
+
+`storages` 仅列出已配置可用的后端。
+
+### 3.2 kvault_token_info
+
+```bash
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/me"
+```
+
+返回 `data.token`：`id / name / scopes / expiresAt / enabled / policies / createdAt / lastUsedAt / usageCount`。适合 Agent 启动时自检凭据权限。
+
+### 3.3 kvault_upload_file
+
+| 参数 | 位置 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `file` | form-data | 是 | 文件本体 |
+| `storage` | form-data | 否 | telegram / r2 / s3 / discord / huggingface / webdav / github，缺省用默认存储 |
+| `folderPath` | form-data | 否 | 目录前缀 |
+| `slug` | form-data | 否 | 自定义分享 slug（冲突返回 409 `SLUG_CONFLICT`） |
+| `expires_in` | form-data | 否 | 分享链接有效秒数 |
+| `max_downloads` | form-data | 否 | 分享下载次数上限 |
+| `password` | form-data | 否 | 分享密码 |
+
+```bash
+curl -X POST "https://your-kvault-domain/api/v1/upload" \
+  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -H "Idempotency-Key: post-42-cover" \
+  -F "file=@./cover.png" -F "storage=r2" -F "folderPath=blog/2026"
+```
+
+成功：`{"success":true,"file":{"id":"...","name":"cover.png",...},"links":{"download":"...","share":"...","delete":"..."}}`。≤25MB 的重复内容上传会命中 SHA-256 去重索引，响应附加 `"deduplicated": true` 并返回已有文件。
+
+### 3.4 kvault_import_url
+
+| 参数 | 位置 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `url` | JSON | 是 | 远程地址 |
+| `storage` | JSON | 否 | 同上传 |
+| `folder` | JSON | 否 | 目录前缀 |
+| `deduplicate` | JSON | 否 | 默认 `true`，设为 `false` 跳过去重 |
+
+```bash
+curl -X POST "https://your-kvault-domain/api/v1/import" \
+  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: agent-run-20260903-1" \
+  -d '{"url":"https://cdn.example.com/cover.jpg","storage":"r2","folder":"agent"}'
+```
+
+返回 `data.file`（含 `sha256`）、`data.links.download / share`、`data.source.url`、`data.deduplicated`。
+
+SSRF 防护：仅允许 http/https；端口白名单 80 / 443 / 8080 / 8443；内网、环回、链路本地、CGNAT、云厂商 metadata 主机与字面 IP 一律拒绝（Docker 侧对每个 DNS 解析结果复检）；每一跳重定向都重新校验。
+
+### 3.5 kvault_list_files
+
+```bash
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" \
+  "https://your-kvault-domain/api/v1/files?limit=50&storage=r2&search=cover"
+```
+
+可选 query：`limit`（默认 50，最大 200）、`cursor`、`storage`、`search`、`listType`、`folderPath`。返回 `files[]` 与 `pagination{cursor, listComplete, pageCount, total}`；下一页传 `cursor=<pagination.cursor>`。
+
+### 3.6 kvault_get_file
+
+```bash
+# 元信息（JSON，含原始字段 raw）
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/file/<id>/info"
+
+# 字节流（支持 Range，受分享密码保护约束）
+curl -H "Authorization: Bearer $KVAULT_API_TOKEN" "https://your-kvault-domain/api/v1/file/<id>"
+```
+
+## 4. 其他端点
+
+- `POST /api/v1/paste`（scope: `paste`）：`{"content":"...","language":"text","expires_in":86400,"password":""}` → 201 + `paste{id, language, createdAt, expiresAt, hasPassword}` 与 `links.view / links.raw`。
+- `GET /api/v1/pastes`：分页列表。
+- `DELETE /api/v1/file/:id`（scope: `delete`）：删除文件。
+
+## 5. 安全须知（Agent 开发者）
+
+1. Token 明文只在创建/轮换时返回一次，服务端只存哈希；疑似泄露立即 rotate，旧密钥即刻失效。
+2. 禁用的 Token 立即失效，且不能被任何遥测写入"复活"（用量统计与凭据分离存储，60 秒防抖）。
+3. 上传默认拒绝 SVG；URL 导入仅 http(s) + 端口白名单。
+4. 为 Agent 配最小权限：推荐 `upload` scope + `folderPrefix` 策略。
+5. 浏览器前端直连需配置 `API_CORS_ORIGINS` 白名单；纯服务端调用无需 CORS。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,401 @@
+openapi: 3.0.3
+info:
+  title: K-Vault API
+  version: '1.0'
+  description: |
+    K-Vault machine-facing API. Identical behavior on Docker and Cloudflare Pages
+    deployments (parity contract).
+
+    Authentication uses long-lived API Tokens (`kvault_<id>_<secret>`) via the
+    `Authorization: Bearer` header. Tokens carry scopes (upload/read/delete/paste)
+    and optional policies (allowedStorages / allowedMimeTypes / maxFileSize /
+    folderPrefix / allowedSourceHosts).
+
+    Conventions:
+    - Idempotency: send an `Idempotency-Key` header (<= 200 chars) on upload/import;
+      repeated requests with the same key replay the original response for 24h.
+    - Small uploads (<= 25MB) are content-deduplicated by SHA-256 (90-day window).
+    - Errors return `{ "success": false, "error": { "code", "message", ... } }`.
+servers:
+  - url: '{baseUrl}'
+    variables:
+      baseUrl:
+        default: https://your-kvault.example.com
+security:
+  - bearerAuth: []
+tags:
+  - name: Assets
+  - name: Account
+  - name: Admin
+paths:
+  /api/v1/capabilities:
+    get:
+      tags: [Account]
+      summary: Public capabilities discovery (no token required)
+      security: []
+      responses:
+        '200':
+          description: Configured storages, limits and feature flags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      apiVersion: { type: string, example: 'v1' }
+                      upload: { type: boolean }
+                      importFromUrl: { type: boolean }
+                      maxUploadSize: { type: integer }
+                      storages:
+                        type: array
+                        items: { type: string }
+                      imageTypes:
+                        type: array
+                        items: { type: string }
+  /api/v1/me:
+    get:
+      tags: [Account]
+      summary: Introspect the current token
+      responses:
+        '200':
+          description: Token metadata and live usage stats (no secret material)
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/v1/upload:
+    post:
+      tags: [Assets]
+      summary: Upload a file (scope: upload)
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                storage:
+                  type: string
+                  enum: [telegram, r2, s3, discord, huggingface, webdav, github]
+                folderPath:
+                  type: string
+                password:
+                  type: string
+                expires_in:
+                  type: integer
+                  description: Seconds until the file expires.
+                max_downloads:
+                  type: integer
+                slug:
+                  type: string
+                deduplicate:
+                  type: boolean
+                  default: true
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: |
+            Upload result. Legacy-compatible shape: `{ success, file, links }`.
+            When `deduplicated: true` an identical file already existed and the
+            existing file's links are returned.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/PolicyDenied' }
+        '413': { $ref: '#/components/responses/TooLarge' }
+  /api/v1/import:
+    post:
+      tags: [Assets]
+      summary: Import an image from a remote URL (scope: upload)
+      description: |
+        Server-side fetch with full SSRF protection: every redirect hop is
+        re-validated (private ranges, link-local, CGNAT, metadata hosts are
+        blocked), size is enforced while streaming, Content-Type is sniffed and
+        matched, SVG is rejected.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url:
+                  type: string
+                  format: uri
+                storage:
+                  type: string
+                folder:
+                  type: string
+                deduplicate:
+                  type: boolean
+                  default: true
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: |
+            `{ success, data: { file: { id, name, size, mime, sha256, storage },
+            links: { download, share }, source: { url }, deduplicated } }`
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '403': { $ref: '#/components/responses/PolicyDenied' }
+        '413': { $ref: '#/components/responses/TooLarge' }
+        '415':
+          description: Unsupported media type (e.g. SVG) or MIME mismatch
+        '502':
+          description: Remote fetch failed or SSRF guard blocked the target
+  /api/v1/files:
+    get:
+      tags: [Assets]
+      summary: List files (scope: read)
+      responses:
+        '200': { description: Paginated file list }
+  /api/v1/file/{id}:
+    get:
+      tags: [Assets]
+      summary: Download or inspect a file (scope: read)
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200': { description: File bytes or metadata }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Assets]
+      summary: Delete a file (scope: delete)
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200': { description: Deleted }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/v1/paste:
+    post:
+      tags: [Assets]
+      summary: Create a text paste (scope: paste)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content: { type: string }
+                language: { type: string, default: text }
+      responses:
+        '201': { description: Created paste }
+  /api/v1/pastes:
+    get:
+      tags: [Assets]
+      summary: List pastes (scope: read)
+      responses:
+        '200': { description: Paste list }
+  /api/v1/paste/{id}:
+    get:
+      tags: [Assets]
+      summary: Read a paste (scope: read)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Paste content }
+    delete:
+      tags: [Assets]
+      summary: Delete a paste (scope: delete)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Deleted }
+  /api/admin/tokens:
+    get:
+      tags: [Admin]
+      summary: List API tokens (admin session or Basic auth)
+      responses:
+        '200': { description: Token list with redacted records }
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+    post:
+      tags: [Admin]
+      summary: Create an API token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, scopes]
+              properties:
+                name: { type: string, maxLength: 64 }
+                scopes:
+                  type: array
+                  items:
+                    type: string
+                    enum: [upload, read, delete, paste]
+                expiresAtMs: { type: integer, description: Explicit epoch-ms expiry }
+                expiresAt:
+                  type: string
+                  format: date-time
+                  description: ISO-8601. Bare numeric values are rejected (INVALID_EXPIRY).
+                policies:
+                  $ref: '#/components/schemas/TokenPolicies'
+      responses:
+        '201':
+          description: |
+            `{ success, token: "kvault_...", tokenInfo }`. The full secret is
+            returned exactly once.
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+  /api/admin/tokens/{id}:
+    patch:
+      tags: [Admin]
+      summary: Update enabled / name / scopes / expiry / policies
+      parameters:
+        - $ref: '#/components/parameters/TokenId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled: { type: boolean }
+                name: { type: string }
+                scopes:
+                  type: array
+                  items: { type: string }
+                expiresAtMs: { type: integer }
+                expiresAt: { type: string, format: date-time }
+                policies:
+                  $ref: '#/components/schemas/TokenPolicies'
+      responses:
+        '200': { description: Updated token (public record) }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+    delete:
+      tags: [Admin]
+      summary: Delete a token and its telemetry
+      parameters:
+        - $ref: '#/components/parameters/TokenId'
+      responses:
+        '200': { description: Deleted }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+  /api/admin/tokens/{id}/rotate:
+    post:
+      tags: [Admin]
+      summary: Rotate the token secret (requirement #7)
+      description: |
+        Issues a new secret for the same identity/scopes/policies. The old
+        secret stops working immediately. The new secret is returned exactly
+        once. `rotatedAt` is stamped on the record.
+      parameters:
+        - $ref: '#/components/parameters/TokenId'
+      responses:
+        '200': { description: New secret + updated record }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+  /api/admin/audit-logs:
+    get:
+      tags: [Admin]
+      summary: Query the security audit log (180-day retention)
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 100, maximum: 500 }
+      responses:
+        '200':
+          description: Events include TOKEN_CREATED/ROTATED/DISABLED/ENABLED/SCOPE_CHANGED/DELETED/VERIFY_FAILED
+        '503': { $ref: '#/components/responses/AdminAuthNotConfigured' }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: 'API Token: kvault_<id>_<secret>'
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      schema: { type: string, maxLength: 200 }
+      description: Replay-safe operation key (24h window).
+    FileId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+    TokenId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+  schemas:
+    TokenPolicies:
+      type: object
+      nullable: true
+      properties:
+        allowedStorages:
+          type: array
+          items:
+            type: string
+            enum: [telegram, r2, s3, discord, huggingface, webdav, github]
+        allowedMimeTypes:
+          type: array
+          items: { type: string }
+        maxFileSize:
+          type: integer
+          description: Bytes; <= 1GiB.
+        folderPrefix:
+          type: string
+          description: folderPath must equal this prefix or live under it.
+        allowedSourceHosts:
+          type: array
+          items: { type: string }
+          description: Origin/Referer hostname allow-list for import requests.
+  responses:
+    Unauthorized:
+      description: Missing/invalid token
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    ValidationError:
+      description: Invalid input (INVALID_SCOPE / INVALID_EXPIRY / INVALID_POLICY / VALIDATION_ERROR / INVALID_STORAGE)
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    PolicyDenied:
+      description: Token policy rejected the operation (POLICY_DENIED)
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    TooLarge:
+      description: File exceeds the storage/token limit (FILE_TOO_LARGE / POLICY_FILE_TOO_LARGE)
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    AdminAuthNotConfigured:
+      description: |
+        Admin API fails closed: no admin credentials are configured. Set
+        BASIC_USER and BASIC_PASS to enable it.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Error:
+      type: object
+      properties:
+        success: { type: boolean, example: false }
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }

--- a/functions/api/admin/_middleware.js
+++ b/functions/api/admin/_middleware.js
@@ -1,8 +1,27 @@
 import { checkAuthentication, isAuthRequired } from '../../utils/auth.js';
 import { apiError } from '../../utils/api-v1.js';
+import { handleApiPreflight } from '../../utils/cors.js';
 
+/**
+ * Admin API middleware (requirement #1 — fail closed).
+ *
+ * /api/admin/** ALWAYS requires admin authentication:
+ * - KV binding missing            -> 500 SERVER_MISCONFIGURED
+ * - No BASIC_USER/BASIC_PASS set  -> 503 ADMIN_AUTH_NOT_CONFIGURED
+ * - Invalid/expired credentials   -> 401 UNAUTHORIZED
+ *
+ * Public browse / guest upload modes never grant anonymous admin access.
+ * /api/admin/** is never opened for cross-origin access (preflight answers
+ * 204 without ACAO, browser blocks the actual request).
+ */
 export async function onRequest(context) {
-  if (!context.env?.img_url) {
+  const { request, env } = context;
+
+  if (request.method === 'OPTIONS') {
+    return handleApiPreflight(request, env);
+  }
+
+  if (!env?.img_url) {
     return apiError(
       'SERVER_MISCONFIGURED',
       'KV binding img_url is not configured.',
@@ -10,14 +29,18 @@ export async function onRequest(context) {
     );
   }
 
-  if (!isAuthRequired(context.env)) {
-    return context.next();
+  if (!isAuthRequired(env)) {
+    return apiError(
+      'ADMIN_AUTH_NOT_CONFIGURED',
+      'Admin API requires BASIC_USER and BASIC_PASS to be configured. Admin endpoints fail closed when no admin credential is set.',
+      503
+    );
   }
 
   const authResult = await checkAuthentication(context);
-  if (authResult.authenticated) {
-    return context.next();
+  if (!authResult.authenticated) {
+    return apiError('UNAUTHORIZED', 'Admin authentication required.', 401);
   }
 
-  return apiError('UNAUTHORIZED', 'You need to login.', 401);
+  return context.next();
 }

--- a/functions/api/admin/tokens.js
+++ b/functions/api/admin/tokens.js
@@ -2,26 +2,14 @@ import {
   createApiToken,
   getApiTokenScopes,
   listApiTokens,
+  parseExpiryInput,
 } from '../../utils/api-token.js';
-import { apiError, apiSuccess, parsePositiveInt } from '../../utils/api-v1.js';
+import { apiError, apiSuccess, tokenErrorResponse, parseTokenExpiryFromBody } from '../../utils/api-v1.js';
+import { writeAuditLog, AUDIT_EVENTS } from '../../utils/audit.js';
 
-function normalizeExpiryInput(body = {}) {
-  if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
-    return body.expiresAt;
-  }
-  if (Object.prototype.hasOwnProperty.call(body, 'expires_in')) {
-    const seconds = parsePositiveInt(body.expires_in, { defaultValue: 0, min: 1, max: 3650 * 24 * 3600 });
-    return seconds > 0 ? Date.now() + seconds * 1000 : null;
-  }
-  if (Object.prototype.hasOwnProperty.call(body, 'expiresIn')) {
-    const seconds = parsePositiveInt(body.expiresIn, { defaultValue: 0, min: 1, max: 3650 * 24 * 3600 });
-    return seconds > 0 ? Date.now() + seconds * 1000 : null;
-  }
-  if (Object.prototype.hasOwnProperty.call(body, 'expiresInDays')) {
-    const days = parsePositiveInt(body.expiresInDays, { defaultValue: 0, min: 1, max: 3650 });
-    return days > 0 ? Date.now() + days * 24 * 3600 * 1000 : null;
-  }
-  return null;
+function clientTag(request) {
+  const ua = String(request.headers.get('User-Agent') || '').slice(0, 60);
+  return ua || 'unknown';
 }
 
 export async function onRequest(context) {
@@ -56,15 +44,30 @@ export async function onRequest(context) {
   }
 
   try {
+    const expiry = parseTokenExpiryFromBody(body);
+    const expiresAt = expiry.kind === 'iso'
+      ? parseExpiryInput(expiry.value)
+      : (expiry.kind === 'ms' ? expiry.value : null);
+
     const created = await createApiToken(
       {
         name,
         scopes: body?.scopes || [],
-        expiresAt: normalizeExpiryInput(body),
+        expiresAt,
+        policies: body?.policies,
         enabled: body?.enabled !== false,
       },
       env
     );
+
+    await writeAuditLog(env, {
+      event: AUDIT_EVENTS.TOKEN_CREATED,
+      tokenId: created.record.id,
+      operation: 'admin.tokens.create',
+      success: true,
+      client: clientTag(request),
+      detail: `name="${created.record.name}" scopes=[${created.record.scopes.join(',')}]`,
+    });
 
     return apiSuccess(
       {
@@ -74,6 +77,6 @@ export async function onRequest(context) {
       201
     );
   } catch (error) {
-    return apiError('TOKEN_CREATE_FAILED', error.message || 'Failed to create API Token.', 400);
+    return tokenErrorResponse(error, 'TOKEN_CREATE_FAILED', 400);
   }
 }

--- a/functions/api/admin/tokens/[id].js
+++ b/functions/api/admin/tokens/[id].js
@@ -1,8 +1,17 @@
 import {
   deleteApiToken,
+  getRecordById,
+  parseExpiryInput,
+  rotateApiToken,
   updateApiToken,
 } from '../../../utils/api-token.js';
-import { apiError, apiSuccess, decodePathParam } from '../../../utils/api-v1.js';
+import { apiError, apiSuccess, decodePathParam, tokenErrorResponse, parseTokenExpiryFromBody } from '../../../utils/api-v1.js';
+import { writeAuditLog, AUDIT_EVENTS } from '../../../utils/audit.js';
+
+function clientTag(request) {
+  const ua = String(request.headers.get('User-Agent') || '').slice(0, 60);
+  return ua || 'unknown';
+}
 
 export async function onRequest(context) {
   const { request, params, env } = context;
@@ -35,8 +44,15 @@ export async function onRequest(context) {
       if (Object.prototype.hasOwnProperty.call(body, 'scopes')) {
         patch.scopes = body.scopes;
       }
+      if (Object.prototype.hasOwnProperty.call(body, 'policies')) {
+        patch.policies = body.policies;
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'expiresAtMs')) {
+        const ms = Number(body.expiresAtMs);
+        patch.expiresAt = Number.isFinite(ms) && ms > 0 ? Math.floor(ms) : null;
+      }
       if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
-        patch.expiresAt = body.expiresAt;
+        patch.expiresAt = parseExpiryInput(body.expiresAt);
       }
       if (Object.prototype.hasOwnProperty.call(body, 'expires_in')) {
         const seconds = Number.parseInt(String(body.expires_in), 10);
@@ -47,19 +63,72 @@ export async function onRequest(context) {
         return apiError('VALIDATION_ERROR', 'No token fields provided to update.', 400);
       }
 
-      const token = await updateApiToken(
-        tokenId,
-        patch,
-        env
-      );
+      const previous = await getRecordById(tokenId, env);
+      const updated = await updateApiToken(tokenId, patch, env);
 
-      if (!token) {
+      if (!updated) {
         return apiError('TOKEN_NOT_FOUND', 'API Token not found.', 404);
       }
 
-      return apiSuccess({ token });
+      // Audit: distinguish scope changes and enable/disable (requirement #12).
+      if (Object.prototype.hasOwnProperty.call(patch, 'enabled') && previous && previous.enabled !== updated.record.enabled) {
+        await writeAuditLog(env, {
+          event: updated.record.enabled ? AUDIT_EVENTS.TOKEN_ENABLED : AUDIT_EVENTS.TOKEN_DISABLED,
+          tokenId,
+          operation: 'admin.tokens.update',
+          success: true,
+          client: clientTag(request),
+        });
+      }
+      if (Object.prototype.hasOwnProperty.call(patch, 'scopes')) {
+        await writeAuditLog(env, {
+          event: AUDIT_EVENTS.TOKEN_SCOPE_CHANGED,
+          tokenId,
+          operation: 'admin.tokens.update',
+          success: true,
+          client: clientTag(request),
+          detail: `scopes=[${updated.record.scopes.join(',')}]`,
+        });
+      }
+
+      return apiSuccess({ token: updated.record });
     } catch (error) {
-      return apiError('TOKEN_UPDATE_FAILED', error.message || 'Failed to update API Token.', 400);
+      return tokenErrorResponse(error, 'TOKEN_UPDATE_FAILED', 400);
+    }
+  }
+
+  if (request.method === 'POST') {
+    // POST /api/admin/tokens/:id with { action: "rotate" } (requirement #7).
+    // Also routed here because [id].js sees POST for sub-actions.
+    let body = {};
+    try {
+      body = await request.json();
+    } catch {
+      body = {};
+    }
+
+    if (String(body?.action || '').toLowerCase() !== 'rotate') {
+      return apiError('VALIDATION_ERROR', 'Unsupported action. Use { "action": "rotate" }.', 400);
+    }
+
+    try {
+      const rotated = await rotateApiToken(tokenId, env);
+      if (!rotated) {
+        return apiError('TOKEN_NOT_FOUND', 'API Token not found.', 404);
+      }
+
+      await writeAuditLog(env, {
+        event: AUDIT_EVENTS.TOKEN_ROTATED,
+        tokenId,
+        operation: 'admin.tokens.rotate',
+        success: true,
+        client: clientTag(request),
+      });
+
+      // Full new secret is returned exactly once (requirement #7).
+      return apiSuccess({ token: rotated.token, tokenInfo: rotated.record });
+    } catch (error) {
+      return tokenErrorResponse(error, 'TOKEN_ROTATE_FAILED', 400);
     }
   }
 
@@ -68,6 +137,15 @@ export async function onRequest(context) {
     if (!deleted) {
       return apiError('TOKEN_NOT_FOUND', 'API Token not found.', 404);
     }
+
+    await writeAuditLog(env, {
+      event: AUDIT_EVENTS.TOKEN_DELETED,
+      tokenId,
+      operation: 'admin.tokens.delete',
+      success: true,
+      client: clientTag(request),
+    });
+
     return apiSuccess({ deleted: true });
   }
 

--- a/functions/api/admin/tokens/[id]/rotate.js
+++ b/functions/api/admin/tokens/[id]/rotate.js
@@ -1,0 +1,40 @@
+import { rotateApiToken } from '../../../../utils/api-token.js';
+import { apiError, apiSuccess, decodePathParam, tokenErrorResponse } from '../../../../utils/api-v1.js';
+import { writeAuditLog, AUDIT_EVENTS } from '../../../../utils/audit.js';
+
+/**
+ * POST /api/admin/tokens/:id/rotate (requirement #7).
+ * New secret is generated, old secret dies immediately. The full new secret
+ * is returned exactly once and never again in list APIs.
+ */
+export async function onRequestPost(context) {
+  const { params, env, request } = context;
+  const tokenId = decodePathParam(params?.id || '');
+
+  if (!tokenId) {
+    return apiError('VALIDATION_ERROR', 'Token id is required.', 400);
+  }
+
+  try {
+    const rotated = await rotateApiToken(tokenId, env);
+    if (!rotated) {
+      return apiError('TOKEN_NOT_FOUND', 'API Token not found.', 404);
+    }
+
+    await writeAuditLog(env, {
+      event: AUDIT_EVENTS.TOKEN_ROTATED,
+      tokenId,
+      operation: 'admin.tokens.rotate',
+      success: true,
+      client: String(request.headers.get('User-Agent') || '').slice(0, 60) || 'unknown',
+    });
+
+    return apiSuccess({ token: rotated.token, tokenInfo: rotated.record });
+  } catch (error) {
+    return tokenErrorResponse(error, 'TOKEN_ROTATE_FAILED', 400);
+  }
+}
+
+export async function onRequest(context) {
+  return apiError('METHOD_NOT_ALLOWED', 'Method not allowed.', 405);
+}

--- a/functions/api/v1/_middleware.js
+++ b/functions/api/v1/_middleware.js
@@ -1,9 +1,12 @@
 import {
+  checkTokenRateLimit,
   parseBearerToken,
-  touchApiTokenLastUsed,
+  touchApiTokenUsage,
   verifyApiToken,
 } from '../../utils/api-token.js';
 import { apiError } from '../../utils/api-v1.js';
+import { handleApiPreflight, resolveCorsHeaders } from '../../utils/cors.js';
+import { writeAuditLog, AUDIT_EVENTS } from '../../utils/audit.js';
 
 function resolveRequiredScope(request) {
   const pathname = new URL(request.url).pathname.replace(/\/+$/, '');
@@ -13,7 +16,14 @@ function resolveRequiredScope(request) {
   if (!pathname.startsWith(base)) return '';
   const subPath = pathname.slice(base.length) || '/';
 
+  // Public, no bearer required:
+  if (method === 'GET' && subPath === '/capabilities') return '';
+
+  // Introspection: any valid token, no specific scope ("@me" sentinel).
+  if (method === 'GET' && subPath === '/me') return '@me';
+
   if (method === 'POST' && subPath === '/upload') return 'upload';
+  if (method === 'POST' && subPath === '/import') return 'upload';
   if (method === 'GET' && subPath === '/files') return 'read';
   if (method === 'GET' && /^\/file\/[^/]+$/.test(subPath)) return 'read';
   if (method === 'GET' && /^\/file\/[^/]+\/info$/.test(subPath)) return 'read';
@@ -27,12 +37,19 @@ function resolveRequiredScope(request) {
   return '';
 }
 
+function clientTag(request) {
+  return String(request.headers.get('User-Agent') || '').slice(0, 60) || 'unknown';
+}
+
 export async function onRequest(context) {
-  if (context.request.method === 'OPTIONS') {
-    return context.next();
+  const { request, env } = context;
+
+  // Preflight: always 204, never requires a Bearer token (requirement #3).
+  if (request.method === 'OPTIONS') {
+    return handleApiPreflight(request, env);
   }
 
-  if (!context.env?.img_url) {
+  if (!env?.img_url) {
     return apiError(
       'SERVER_MISCONFIGURED',
       'KV binding img_url is not configured.',
@@ -40,31 +57,91 @@ export async function onRequest(context) {
     );
   }
 
-  const requiredScope = resolveRequiredScope(context.request);
-  if (!requiredScope) {
-    return context.next();
+  const corsHeaders = resolveCorsHeaders(request, env);
+
+  const requiredScope = resolveRequiredScope(request);
+
+  if (requiredScope === '') {
+    const response = await context.next();
+    applyCorsToResponse(response, corsHeaders);
+    return response;
   }
 
-  const tokenValue = parseBearerToken(context.request);
-  const verifyResult = await verifyApiToken(tokenValue, context.env, requiredScope);
+  const tokenValue = parseBearerToken(request);
+  const verifyResult = await verifyApiToken(tokenValue, env, requiredScope);
 
   if (!verifyResult.ok) {
-    return apiError(
+    // Usage telemetry for failed verification (tokenId when parseable) and an
+    // audit trail entry; both never block the response flow.
+    const failedId = parseBearerToken(request);
+    context.waitUntil?.(Promise.resolve(
+      touchApiTokenUsage(extractTokenId(failedId), env, {
+        success: false,
+        operation: `${request.method} ${new URL(request.url).pathname}`,
+        client: clientTag(request),
+      })
+    ).catch(() => {}));
+    context.waitUntil?.(writeAuditLog(env, {
+      event: AUDIT_EVENTS.TOKEN_VERIFY_FAILED,
+      operation: `${request.method} ${new URL(request.url).pathname}`,
+      success: false,
+      client: clientTag(request),
+      detail: verifyResult.code || 'TOKEN_INVALID',
+    }).catch(() => {}));
+
+    const errorResponse = apiError(
       verifyResult.code || 'TOKEN_INVALID',
       verifyResult.message || 'API Token is invalid.',
       verifyResult.status || 401
     );
+    applyCorsToResponse(errorResponse, corsHeaders);
+    return errorResponse;
+  }
+
+  // Per-token rate limit (requirement #10).
+  const rateLimit = await checkTokenRateLimit(verifyResult.token, env);
+  if (!rateLimit.allowed) {
+    const limited = apiError('RATE_LIMITED', 'API Token rate limit exceeded.', 429, {
+      retryAfterMs: rateLimit.retryAfterMs,
+    });
+    limited.headers.set('Retry-After', String(Math.ceil(rateLimit.retryAfterMs / 1000)));
+    applyCorsToResponse(limited, corsHeaders);
+    return limited;
   }
 
   context.data = context.data || {};
   context.data.apiToken = verifyResult.token;
 
-  const touchPromise = touchApiTokenLastUsed(verifyResult.token.id, context.env).catch((error) => {
-    console.warn('Failed to update API token lastUsedAt:', error?.message || error);
+  // Telemetry: writes only the stat key, 60s sampled (requirement #2).
+  const touchPromise = touchApiTokenUsage(verifyResult.token.id, env, {
+    success: true,
+    operation: `${request.method} ${new URL(request.url).pathname}`.slice(0, 64),
+    client: clientTag(request),
+  }).catch((error) => {
+    console.warn('Failed to update API token usage stats:', error?.message || error);
   });
   if (typeof context.waitUntil === 'function') {
     context.waitUntil(touchPromise);
   }
 
-  return context.next();
+  const response = await context.next();
+  applyCorsToResponse(response, corsHeaders);
+  return response;
+}
+
+function applyCorsToResponse(response, corsHeaders) {
+  if (!response || !response.headers) return response;
+  Object.entries(corsHeaders).forEach(([key, value]) => {
+    try {
+      response.headers.set(key, value);
+    } catch {
+      // immutable headers are fine to skip
+    }
+  });
+  return response;
+}
+
+function extractTokenId(tokenValue) {
+  const match = /^kvault_([A-Za-z0-9_-]{6,128})_/.exec(String(tokenValue || '').trim());
+  return match ? match[1] : '';
 }

--- a/functions/api/v1/capabilities.js
+++ b/functions/api/v1/capabilities.js
@@ -1,0 +1,55 @@
+import { apiSuccess } from '../../utils/api-v1.js';
+
+/**
+ * GET /api/v1/capabilities (requirement #5) — public, no Bearer required.
+ * Reports only storage backends that are actually configured on this
+ * deployment, so agents can pick a target without probing.
+ */
+
+const API_VERSION = 'v1';
+const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif'];
+const MAX_UPLOAD_SIZE = 100 * 1024 * 1024; // 100MB (Pages hard limit)
+
+export function detectConfiguredStorages(env) {
+  const storages = [];
+
+  if ((env.TG_BOT_TOKEN || '').trim() && ((env.TG_CHAT_ID || '').trim() || (env.TG_Chat_ID || '').trim())) {
+    storages.push('telegram');
+  }
+  if (env.R2_BUCKET) {
+    storages.push('r2');
+  }
+  if ((env.S3_ENDPOINT || '').trim() && (env.S3_ACCESS_KEY_ID || '').trim() && (env.S3_BUCKET || '').trim()) {
+    storages.push('s3');
+  }
+  if ((env.DISCORD_WEBHOOK_URL || '').trim() || (env.DISCORD_BOT_TOKEN || '').trim()) {
+    storages.push('discord');
+  }
+  if ((env.HF_TOKEN || '').trim() && (env.HF_REPO || '').trim()) {
+    storages.push('huggingface');
+  }
+  if ((env.WEBDAV_BASE_URL || '').trim() && ((env.WEBDAV_BEARER_TOKEN || '').trim() || (env.WEBDAV_USERNAME || '').trim())) {
+    storages.push('webdav');
+  }
+  if ((env.GITHUB_REPO || '').trim() && (env.GITHUB_TOKEN || '').trim()) {
+    storages.push('github');
+  }
+
+  return storages;
+}
+
+export async function onRequestGet(context) {
+  const { env } = context;
+  const storages = detectConfiguredStorages(env);
+
+  return apiSuccess({
+    data: {
+      apiVersion: API_VERSION,
+      upload: storages.length > 0,
+      importFromUrl: true,
+      maxUploadSize: MAX_UPLOAD_SIZE,
+      storages,
+      imageTypes: IMAGE_TYPES,
+    },
+  });
+}

--- a/functions/api/v1/import.js
+++ b/functions/api/v1/import.js
@@ -1,0 +1,569 @@
+import { createS3Client } from '../../utils/s3client.js';
+import { uploadToDiscord } from '../../utils/discord.js';
+import { hasHuggingFaceConfig, uploadToHuggingFace } from '../../utils/huggingface.js';
+import { hasWebDAVConfig, normalizeWebDAVPath, uploadToWebDAV } from '../../utils/webdav.js';
+import { hasGitHubConfig, normalizeGitHubStoragePath, uploadToGitHub } from '../../utils/github.js';
+import {
+  buildTelegramBotApiUrl,
+  buildTelegramDirectLink,
+  createSignedTelegramFileId,
+  getTelegramUploadMethodAndField,
+  pickTelegramFileId,
+  sendTelegramUploadNotice,
+  shouldUseSignedTelegramLinks,
+  shouldWriteTelegramMetadata,
+} from '../../utils/telegram.js';
+import { apiError, apiSuccess } from '../../utils/api-v1.js';
+import { checkUploadPolicy } from '../../utils/policy-enforce.js';
+import { MAX_REDIRECTS, sniffImageMime, validateRedirectLocation, validateRemoteUrl } from '../../utils/ssrf-guard.js';
+
+/**
+ * POST /api/v1/import (requirement #6).
+ * Agent-facing remote image import: server-side download with strict SSRF
+ * protections, MIME sniffing, streaming size cap, SHA-256, content
+ * deduplication and storage routing. Requires "upload" scope (middleware).
+ */
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 30000;
+const MB = 1024 * 1024;
+const DEDUP_TTL_SECONDS = 90 * 24 * 3600;
+
+const STORAGE_LIMITS = {
+  discord: { maxBytes: 25 * MB, message: 'Discord uploads are capped at 25MB.' },
+  huggingface: { maxBytes: 35 * MB, message: 'HuggingFace uploads are capped at 35MB.' },
+  telegram: { maxBytes: 50 * MB, message: 'Telegram uploads are capped at 50MB.' },
+};
+
+class ImportError extends Error {
+  constructor(code, message, status = 400) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function normalizeFolderPath(value) {
+  const raw = String(value || '').replace(/\\/g, '/').trim();
+  const output = [];
+  for (const part of raw.split('/')) {
+    const piece = part.trim();
+    if (!piece || piece === '.') continue;
+    if (piece === '..') { output.pop(); continue; }
+    output.push(piece);
+  }
+  return output.join('/');
+}
+
+function joinStoragePath(folderPath, fileName) {
+  const base = normalizeFolderPath(folderPath);
+  return base ? `${base}/${fileName}` : fileName;
+}
+
+function getExtensionFromMime(mime) {
+  const map = {
+    'image/jpeg': 'jpg', 'image/png': 'png', 'image/gif': 'gif',
+    'image/webp': 'webp', 'image/avif': 'avif', 'image/bmp': 'bmp',
+    'image/x-icon': 'ico',
+  };
+  return map[mime] || 'bin';
+}
+
+function randomId(prefix) {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+}
+
+async function sha256HexBuffer(buffer) {
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/** Strict remote fetch with SSRF checks on every redirect hop. */
+async function fetchRemoteStrict(rawUrl, maxBytes) {
+  let currentUrl;
+  try {
+    currentUrl = new URL(String(rawUrl || '').trim());
+  } catch {
+    throw new ImportError('INVALID_URL', 'Invalid URL.', 400);
+  }
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const check = validateRemoteUrl(currentUrl.href);
+    if (!check.ok) throw new ImportError(check.code, check.message, 400);
+
+    let response;
+    try {
+      response = await fetch(currentUrl.href, {
+        redirect: 'manual',
+        headers: { 'User-Agent': 'K-Vault-Import/1.0' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw new ImportError('IMPORT_UPSTREAM_ERROR', `Remote fetch failed: ${error?.message || 'network error'}`, 502);
+    }
+
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      const location = response.headers.get('Location');
+      if (!location) throw new ImportError('IMPORT_UPSTREAM_ERROR', 'Redirect response without Location header.', 502);
+      const redirectCheck = validateRedirectLocation(location, currentUrl);
+      if (!redirectCheck.ok) throw new ImportError(redirectCheck.code, redirectCheck.message, 400);
+      currentUrl = redirectCheck.url;
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new ImportError('IMPORT_UPSTREAM_ERROR', `Upstream returned HTTP ${response.status}.`, 502);
+    }
+
+    // Content-Length is a pre-check only; the stream cap below is authoritative.
+    const contentLength = Number(response.headers.get('Content-Length') || 0);
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw new ImportError('IMPORT_TOO_LARGE', `Remote file exceeds the ${maxBytes} byte limit.`, 413);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new ImportError('IMPORT_EMPTY', 'Remote response has no body.', 400);
+
+    const chunks = [];
+    let received = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > maxBytes) {
+          throw new ImportError('IMPORT_TOO_LARGE', `Remote file exceeds the ${maxBytes} byte limit.`, 413);
+        }
+        chunks.push(value);
+      }
+    } catch (error) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      if (error instanceof ImportError) throw error;
+      throw new ImportError('IMPORT_UPSTREAM_ERROR', `Download interrupted: ${error?.message || 'stream error'}`, 502);
+    }
+
+    const buffer = concatChunks(chunks, received);
+    if (buffer.byteLength === 0) {
+      throw new ImportError('IMPORT_EMPTY', 'Remote file is empty.', 400);
+    }
+
+    return { buffer, contentType: response.headers.get('Content-Type') || '', finalUrl: currentUrl };
+  }
+
+  throw new ImportError('SSRF_BLOCKED', `Too many redirects (max ${MAX_REDIRECTS}).`, 400);
+}
+
+function concatChunks(chunks, totalLength) {
+  const output = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output.buffer;
+}
+
+/** Decide the final MIME: sniffed magic bytes win; SVG is rejected by default. */
+function resolveImportMime(buffer, contentTypeHeader, fileName) {
+  const sniffed = sniffImageMime(new Uint8Array(buffer.slice(0, 32)));
+  const header = String(contentTypeHeader || '').split(';')[0].trim().toLowerCase();
+  const name = String(fileName || '').toLowerCase();
+
+  if (header === 'image/svg+xml' || name.endsWith('.svg')) {
+    throw new ImportError('IMPORT_MIME_BLOCKED', 'SVG imports are disabled by default (XSS risk).', 415);
+  }
+  if (!sniffed) {
+    // Text-based rejection: XML/SVG payloads sniff as null.
+    const head = new TextDecoder().decode(new Uint8Array(buffer.slice(0, 256))).trim().toLowerCase();
+    if (head.startsWith('<?xml') || head.startsWith('<svg') || head.includes('<svg')) {
+      throw new ImportError('IMPORT_MIME_BLOCKED', 'SVG imports are disabled by default (XSS risk).', 415);
+    }
+    if (header && header.startsWith('image/') && header !== 'image/svg+xml') {
+      throw new ImportError('IMPORT_MIME_BLOCKED', `Content-Type "${header}" does not match file content.`, 415);
+    }
+    throw new ImportError('IMPORT_MIME_BLOCKED', 'Unsupported file type. Only images (jpeg/png/webp/avif/gif/bmp/ico) can be imported.', 415);
+  }
+  if (header && header.startsWith('image/') && header !== 'image/svg+xml' && header !== sniffed) {
+    // header/sniff mismatch: keep the sniffed value (authoritative).
+  }
+  return sniffed;
+}
+
+function checkStorageLimit(storage, sizeBytes) {
+  const limit = STORAGE_LIMITS[storage];
+  if (limit && sizeBytes > limit.maxBytes) {
+    throw new ImportError('IMPORT_TOO_LARGE', limit.message, 413);
+  }
+}
+
+/* ---------- storage dispatch (KV metadata layout matches upload-from-url) ---------- */
+
+function appendCommonMetadata(metadata, folderPath) {
+  return folderPath ? { ...metadata, folderPath } : metadata;
+}
+
+async function uploadToTelegramStorage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  const file = new File([new Blob([bytes], { type: mime })], fileName, { type: mime });
+  const { method: apiEndpoint, field } = getTelegramUploadMethodAndField(mime);
+
+  const formData = new FormData();
+  formData.append('chat_id', env.TG_Chat_ID || env.TG_CHAT_ID);
+  formData.append(field, file);
+
+  let response = await fetch(buildTelegramBotApiUrl(env, apiEndpoint), { method: 'POST', body: formData });
+  let data = await response.json().catch(() => ({}));
+
+  if (!response.ok && apiEndpoint === 'sendAudio') {
+    const docFormData = new FormData();
+    docFormData.append('chat_id', env.TG_Chat_ID || env.TG_CHAT_ID);
+    docFormData.append('document', file);
+    response = await fetch(buildTelegramBotApiUrl(env, 'sendDocument'), { method: 'POST', body: docFormData });
+    data = await response.json().catch(() => ({}));
+  }
+
+  if (!response.ok) {
+    throw new ImportError('UPLOAD_FAILED', `Telegram upload failed: ${data?.description || 'unknown error'}`, 502);
+  }
+
+  const telegramFileId = pickTelegramFileId(data);
+  if (!telegramFileId) {
+    throw new ImportError('UPLOAD_FAILED', 'Telegram accepted the file but returned no usable file id.', 502);
+  }
+
+  const messageId = data?.result?.message_id;
+  const directId = shouldUseSignedTelegramLinks(env)
+    ? await createSignedTelegramFileId({ fileId: telegramFileId, fileExtension: extension, fileName, mimeType: mime, fileSize, messageId }, env)
+    : `${telegramFileId}.${extension}`;
+
+  if (env.img_url && shouldWriteTelegramMetadata(env)) {
+    await env.img_url.put(`${telegramFileId}.${extension}`, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(),
+        ListType: 'None',
+        Label: 'None',
+        liked: false,
+        fileName,
+        fileSize,
+        storageType: 'telegram',
+        telegramFileId,
+        telegramMessageId: messageId || undefined,
+        signedLink: shouldUseSignedTelegramLinks(env),
+      }, folderPath),
+    });
+  }
+
+  try {
+    await sendTelegramUploadNotice({
+      chatId: env.TG_Chat_ID || env.TG_CHAT_ID,
+      replyToMessageId: messageId || undefined,
+      directLink: buildTelegramDirectLink(env, directId, ''),
+      fileId: telegramFileId,
+      messageId,
+      fileName,
+      fileSize,
+    }, env);
+  } catch { /* notice failures are non-fatal */ }
+
+  return { fileId: `${telegramFileId}.${extension}`, directId };
+}
+
+async function uploadToR2Storage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!env.R2_BUCKET) throw new ImportError('STORAGE_NOT_CONFIGURED', 'R2 is not configured.', 400);
+  const fileId = randomId('r2');
+  const objectKey = `${fileId}.${extension}`;
+  await env.R2_BUCKET.put(objectKey, bytes, {
+    httpMetadata: { contentType: mime },
+    customMetadata: { fileName, uploadTime: Date.now().toString() },
+  });
+  if (env.img_url) {
+    await env.img_url.put(`r2:${objectKey}`, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 'r2', r2Key: objectKey,
+      }, folderPath),
+    });
+  }
+  return { fileId: objectKey, directId: `r2:${objectKey}` };
+}
+
+async function uploadToS3Storage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!env.S3_ENDPOINT || !env.S3_ACCESS_KEY_ID) throw new ImportError('STORAGE_NOT_CONFIGURED', 'S3 is not configured.', 400);
+  const s3 = createS3Client(env);
+  const fileId = randomId('s3');
+  const objectKey = `${fileId}.${extension}`;
+  await s3.putObject(objectKey, bytes, {
+    contentType: mime,
+    metadata: { 'x-amz-meta-filename': fileName, 'x-amz-meta-uploadtime': Date.now().toString() },
+  });
+  if (env.img_url) {
+    await env.img_url.put(`s3:${objectKey}`, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 's3', s3Key: objectKey,
+      }, folderPath),
+    });
+  }
+  return { fileId: objectKey, directId: `s3:${objectKey}` };
+}
+
+async function uploadToDiscordStorage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!env.DISCORD_WEBHOOK_URL && !env.DISCORD_BOT_TOKEN) throw new ImportError('STORAGE_NOT_CONFIGURED', 'Discord is not configured.', 400);
+  const result = await uploadToDiscord(bytes, mime, env);
+  if (!result.success) throw new ImportError('UPLOAD_FAILED', `Discord upload failed: ${result.error}`, 502);
+  const fileId = randomId('discord');
+  const kvKey = `discord:${fileId}.${extension}`;
+  if (env.img_url) {
+    await env.img_url.put(kvKey, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 'discord',
+        discordChannelId: result.channelId, discordMessageId: result.messageId,
+        discordAttachmentId: result.attachmentId, discordUploadMode: result.mode,
+        discordSourceUrl: result.sourceUrl,
+      }, folderPath),
+    });
+  }
+  return { fileId: `${fileId}.${extension}`, directId: kvKey };
+}
+
+async function uploadToHuggingFaceStorage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!hasHuggingFaceConfig(env)) throw new ImportError('STORAGE_NOT_CONFIGURED', 'HuggingFace is not configured.', 400);
+  const fileId = randomId('hf');
+  const hfPath = joinStoragePath(folderPath, `${fileId}.${extension}`);
+  const result = await uploadToHuggingFace(bytes, hfPath, fileName, env);
+  if (!result.success) throw new ImportError('UPLOAD_FAILED', `HuggingFace upload failed: ${result.error}`, 502);
+  const kvKey = `hf:${fileId}.${extension}`;
+  if (env.img_url) {
+    await env.img_url.put(kvKey, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 'huggingface', hfPath,
+      }, folderPath),
+    });
+  }
+  return { fileId: `${fileId}.${extension}`, directId: kvKey };
+}
+
+async function uploadToWebDAVStorage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!hasWebDAVConfig(env)) throw new ImportError('STORAGE_NOT_CONFIGURED', 'WebDAV is not configured.', 400);
+  const fileId = randomId('wd');
+  const publicId = `${fileId}.${extension}`;
+  const webdavPath = joinStoragePath(folderPath, publicId);
+  const result = await uploadToWebDAV(bytes, webdavPath, mime || 'application/octet-stream', env);
+  const kvKey = `webdav:${publicId}`;
+  if (env.img_url) {
+    await env.img_url.put(kvKey, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 'webdav',
+        webdavPath: normalizeWebDAVPath(result.path || webdavPath),
+        webdavEtag: result.etag || undefined,
+      }, folderPath),
+    });
+  }
+  return { fileId: publicId, directId: kvKey };
+}
+
+async function uploadToGitHubStorage(env, { bytes, mime, fileName, extension, fileSize, folderPath }) {
+  if (!hasGitHubConfig(env)) throw new ImportError('STORAGE_NOT_CONFIGURED', 'GitHub is not configured.', 400);
+  const fileId = randomId('github');
+  const publicId = `${fileId}.${extension}`;
+  const githubStorageKey = joinStoragePath(folderPath, publicId);
+  const result = await uploadToGitHub(bytes, normalizeGitHubStoragePath(githubStorageKey), fileName, mime || 'application/octet-stream', env);
+  const kvKey = `github:${publicId}`;
+  if (env.img_url) {
+    await env.img_url.put(kvKey, '', {
+      metadata: appendCommonMetadata({
+        TimeStamp: Date.now(), ListType: 'None', Label: 'None', liked: false,
+        fileName, fileSize, storageType: 'github',
+        githubStorageKey: normalizeGitHubStoragePath(result.storagePath || githubStorageKey),
+        ...(result.metadata || {}),
+      }, folderPath),
+    });
+  }
+  return { fileId: publicId, directId: kvKey };
+}
+
+const STORAGE_DISPATCHERS = {
+  telegram: uploadToTelegramStorage,
+  r2: uploadToR2Storage,
+  s3: uploadToS3Storage,
+  discord: uploadToDiscordStorage,
+  huggingface: uploadToHuggingFaceStorage,
+  webdav: uploadToWebDAVStorage,
+  github: uploadToGitHubStorage,
+};
+
+/* ---------- route handler ---------- */
+
+export async function onRequestPost(context) {
+  const { request, env, data } = context;
+  const token = data?.apiToken;
+
+  let body = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const rawUrl = String(body?.url || '').trim();
+  if (!rawUrl) {
+    return apiError('VALIDATION_ERROR', 'Field "url" is required.', 400);
+  }
+
+  const storage = String(body?.storage || '').trim().toLowerCase() || 'telegram';
+  if (!STORAGE_DISPATCHERS[storage]) {
+    return apiError('VALIDATION_ERROR', `Unknown storage "${storage}". Valid: ${Object.keys(STORAGE_DISPATCHERS).join(', ')}.`, 400);
+  }
+
+  const folderPath = normalizeFolderPath(body?.folder || body?.folderPath || '');
+  const deduplicate = body?.deduplicate === true;
+  const customFileName = String(body?.fileName || '').trim().slice(0, 200);
+
+  // Token size cap (policy) vs global cap.
+  const maxBytes = Math.min(token?.policies?.maxFileSize || MAX_FILE_SIZE, MAX_FILE_SIZE);
+
+  try {
+    // Policy gate (requirement #10) — checked before any network activity.
+    const policyCheck = checkUploadPolicy(token, {
+      storage,
+      mime: 'image/*', // exact MIME enforced after sniffing below
+      sizeBytes: maxBytes,
+      folderPath,
+      request,
+    });
+    if (!policyCheck.ok) {
+      return apiError(policyCheck.code, policyCheck.message, policyCheck.status);
+    }
+
+    // Pre-check folder policy with a placeholder MIME; exact MIME policy is
+    // enforced right after sniffing.
+    const mimePolicyCheck = checkUploadPolicy(token, {
+      storage,
+      mime: 'application/octet-stream',
+      sizeBytes: maxBytes,
+      folderPath,
+      request,
+    });
+    if (mimePolicyCheck.ok === false && mimePolicyCheck.code === 'POLICY_FOLDER_DENIED') {
+      return apiError(mimePolicyCheck.code, mimePolicyCheck.message, mimePolicyCheck.status);
+    }
+    if (mimePolicyCheck.ok === false && mimePolicyCheck.code === 'POLICY_SOURCE_DENIED') {
+      return apiError(mimePolicyCheck.code, mimePolicyCheck.message, mimePolicyCheck.status);
+    }
+    if (mimePolicyCheck.ok === false && mimePolicyCheck.code === 'POLICY_STORAGE_DENIED') {
+      return apiError(mimePolicyCheck.code, mimePolicyCheck.message, mimePolicyCheck.status);
+    }
+
+    // Strict remote fetch (SSRF hardening, streaming size cap).
+    const fetched = await fetchRemoteStrict(rawUrl, maxBytes);
+    const sizeBytes = fetched.buffer.byteLength;
+
+    // MIME sniff (magic bytes win; SVG rejected by default).
+    const mime = resolveImportMime(fetched.buffer, fetched.contentType, new URL(fetched.finalUrl.href).pathname);
+
+    // Exact MIME policy check.
+    const exactMimeCheck = checkUploadPolicy(token, { storage, mime, sizeBytes, folderPath, request });
+    if (!exactMimeCheck.ok) {
+      return apiError(exactMimeCheck.code, exactMimeCheck.message, exactMimeCheck.status);
+    }
+
+    checkStorageLimit(storage, sizeBytes);
+
+    const sha256 = await sha256HexBuffer(fetched.buffer);
+
+    // Content dedup (requirement #11).
+    if (deduplicate) {
+      try {
+        const existing = await env.img_url.get(`sha_dup:${sha256}`, { type: 'json' });
+        if (existing?.directId) {
+          const origin = new URL(request.url).origin;
+          return apiSuccess({
+            data: {
+              file: {
+                id: existing.fileId,
+                name: existing.fileName,
+                size: Number(existing.size || sizeBytes),
+                mime: existing.mime || mime,
+                sha256,
+                storage: existing.storage || storage,
+              },
+              links: {
+                download: `${origin}/file/${encodeURIComponent(existing.directId)}`,
+                share: null,
+              },
+              source: { url: fetched.finalUrl.href },
+              deduplicated: true,
+            },
+          });
+        }
+      } catch { /* dedup index read failure is non-fatal */ }
+    }
+
+    // File name: custom > upstream basename.
+    let fileName = customFileName;
+    if (!fileName) {
+      const upstream = decodeURIComponent((new URL(fetched.finalUrl.href).pathname.split('/').pop() || '').split('?')[0]);
+      fileName = upstream || `import_${Date.now()}.${getExtensionFromMime(mime)}`;
+    }
+    if (!fileName.includes('.')) {
+      fileName = `${fileName}.${getExtensionFromMime(mime)}`;
+    }
+
+    const dispatcher = STORAGE_DISPATCHERS[storage];
+    const uploadResult = await dispatcher(env, {
+      bytes: new Uint8Array(fetched.buffer),
+      mime,
+      fileName,
+      extension: fileName.split('.').pop().toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin',
+      fileSize: sizeBytes,
+      folderPath,
+    });
+
+    // Record dedup index.
+    if (deduplicate) {
+      try {
+        await env.img_url.put(`sha_dup:${sha256}`, JSON.stringify({
+          fileId: uploadResult.fileId,
+          directId: uploadResult.directId,
+          storage,
+          fileName,
+          mime,
+          size: sizeBytes,
+          createdAt: Date.now(),
+        }), { expirationTtl: DEDUP_TTL_SECONDS });
+      } catch { /* dedup index write failure is non-fatal */ }
+    }
+
+    const origin = new URL(request.url).origin;
+    return apiSuccess({
+      data: {
+        file: {
+          id: uploadResult.fileId,
+          name: fileName,
+          size: sizeBytes,
+          mime,
+          sha256,
+          storage,
+        },
+        links: {
+          download: `${origin}/file/${encodeURIComponent(uploadResult.directId)}`,
+          share: null,
+        },
+        source: { url: fetched.finalUrl.href },
+        deduplicated: false,
+      },
+    }, 201);
+  } catch (error) {
+    if (error instanceof ImportError) {
+      return apiError(error.code, error.message, error.status);
+    }
+    console.error('Import failed:', error?.message || error);
+    return apiError('IMPORT_FAILED', error?.message ? String(error.message).slice(0, 300) : 'Import failed.', 500);
+  }
+}
+
+export async function onRequest(context) {
+  return apiError('METHOD_NOT_ALLOWED', 'Method not allowed.', 405);
+}

--- a/functions/api/v1/me.js
+++ b/functions/api/v1/me.js
@@ -1,0 +1,31 @@
+import { apiSuccess } from '../../utils/api-v1.js';
+
+/**
+ * GET /api/v1/me (requirement #4) — Token introspection for any valid token.
+ * Never returns tokenHash, tokenSalt or the full secret.
+ */
+export async function onRequestGet(context) {
+  const token = context.data?.apiToken;
+  if (!token) {
+    // Middleware guarantees this; defensive fallback.
+    return new Response(JSON.stringify({
+      success: false,
+      error: { code: 'TOKEN_INVALID', message: 'API Token is invalid.' },
+    }), { status: 401, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } });
+  }
+
+  return apiSuccess({
+    data: {
+      token: {
+        id: token.id,
+        name: token.name,
+        scopes: [...(token.scopes || [])],
+        expiresAt: token.expiresAt ?? null,
+        enabled: Boolean(token.enabled),
+        policies: token.policies ? { ...token.policies } : null,
+        createdAt: token.createdAt ?? null,
+        lastUsedAt: token.lastUsedAt ?? null,
+      },
+    },
+  });
+}

--- a/functions/api/v1/upload.js
+++ b/functions/api/v1/upload.js
@@ -1,9 +1,63 @@
 import { onRequestPost as uploadInternal } from '../../upload.js';
 import { parseSignedTelegramFileId } from '../../utils/telegram.js';
+import { checkUploadPolicy } from '../../utils/policy-enforce.js';
 import { apiError, apiSuccess, buildAbsoluteUrl, parsePositiveInt } from '../../utils/api-v1.js';
 
 const STORAGE_PREFIXES = ['r2:', 's3:', 'discord:', 'hf:', 'webdav:', 'github:', 'img:', 'vid:', 'aud:', 'doc:', ''];
 const SHARE_SLUG_KEY_PREFIX = 'share_slug:';
+const IDEMPOTENCY_TTL_SECONDS = 24 * 3600;
+const DEDUP_TTL_SECONDS = 90 * 24 * 3600;
+const DEDUP_MAX_INLINE_BYTES = 25 * 1024 * 1024; // pre-upload dedup only for small files
+
+async function sha256HexBuffer(buffer) {
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function idempotencyStoreKey(tokenId, rawKey) {
+  return `idem:${String(tokenId || 'anon')}:${fnv1aHex(String(rawKey || ''))}`;
+}
+
+function fnv1aHex(input) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+async function persistUploadSideEffects(env, apiToken, idempotencyKey, contentSha256, info) {
+  if (!env?.img_url) return;
+  const body = {
+    success: true,
+    file: {
+      id: info.canonicalId || info.publicId,
+      name: info.fileName,
+      size: info.fileSize,
+      type: info.mime,
+      storage: info.storageType,
+      uploadedAt: new Date(info.uploadedAt || Date.now()).toISOString(),
+      ...(contentSha256 ? { sha256: contentSha256 } : {}),
+    },
+    links: {
+      download: buildAbsoluteUrl(info.request, `/file/${encodeURIComponent(info.publicId)}`),
+      share: buildAbsoluteUrl(info.request, `/s/${encodeURIComponent(info.shareId || info.publicId)}`),
+      delete: buildAbsoluteUrl(info.request, `/api/v1/file/${encodeURIComponent(info.canonicalId || info.publicId)}`),
+    },
+    deduplicated: false,
+  };
+  if (idempotencyKey) {
+    try {
+      await env.img_url.put(idempotencyStoreKey(apiToken?.id, idempotencyKey), JSON.stringify({ status: 200, body, createdAt: Date.now() }), { expirationTtl: IDEMPOTENCY_TTL_SECONDS });
+    } catch { /* snapshot failures are non-fatal */ }
+  }
+  if (contentSha256) {
+    try {
+      await env.img_url.put(`sha_dup:${contentSha256}`, JSON.stringify({ publicId: info.publicId, fileName: info.fileName, size: info.fileSize, mime: info.mime, storage: info.storageType, uploadedAt: body.file.uploadedAt }), { expirationTtl: DEDUP_TTL_SECONDS });
+    } catch { /* dedup index failures are non-fatal */ }
+  }
+}
 
 function normalizeStorageType(name = '', metadata = {}) {
   const explicit = metadata.storageType || metadata.storage;
@@ -188,6 +242,20 @@ function resolveUploadErrorStatus(status, message) {
 
 export async function onRequestPost(context) {
   const { request, env } = context;
+  const apiToken = context.data?.apiToken || null;
+  // Idempotency replay (requirement #11): same key returns the saved response.
+  const idempotencyKey = String(request.headers.get('Idempotency-Key') || '').trim().slice(0, 200);
+  if (idempotencyKey && env?.img_url) {
+    try {
+      const saved = await env.img_url.get(idempotencyStoreKey(apiToken?.id, idempotencyKey), { type: 'json' });
+      if (saved?.status && saved?.body) {
+        return new Response(JSON.stringify(saved.body), {
+          status: saved.status,
+          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'Idempotency-Replayed': 'true' },
+        });
+      }
+    } catch { /* replay lookup failure is non-fatal */ }
+  }
 
   let formData;
   try {
@@ -210,6 +278,59 @@ export async function onRequestPost(context) {
   const normalizedSlug = sanitizeSlug(slug);
   if (slug && !normalizedSlug) {
     return apiError('VALIDATION_ERROR', '字段 "slug" 只能包含字母、数字、下划线或短横线。', 400);
+  }
+
+  // Per-token policy enforcement (requirement #10).
+  const folderPath = String(formData.get('folderPath') || formData.get('folder') || url.searchParams.get('folder') || '');
+  const deduplicate = String(formData.get('deduplicate') || url.searchParams.get('deduplicate') || '').toLowerCase() === 'true';
+  const policyCheck = checkUploadPolicy(apiToken, {
+    storage,
+    mime: file.type || mapMimeType(file.name, ''),
+    sizeBytes: file.size,
+    folderPath,
+    request,
+  });
+  if (!policyCheck.ok) {
+    return apiError(policyCheck.code, policyCheck.message, policyCheck.status);
+  }
+
+  // Content dedup for small uploads (requirement #11): identical content returns the existing object.
+  let contentSha256 = '';
+  if (deduplicate && file.size > 0 && file.size <= DEDUP_MAX_INLINE_BYTES && env?.img_url) {
+    try {
+      const bytes = await file.arrayBuffer();
+      contentSha256 = await sha256HexBuffer(bytes);
+      const existing = await env.img_url.get(`sha_dup:${contentSha256}`, { type: 'json' });
+      if (existing?.publicId) {
+        const dedupBody = {
+          success: true,
+          file: {
+            id: existing.publicId,
+            name: existing.fileName || file.name,
+            size: Number(existing.size || file.size),
+            type: existing.mime || file.type || mapMimeType(file.name, 'application/octet-stream'),
+            storage: existing.storage || storage || 'telegram',
+            uploadedAt: existing.uploadedAt || new Date().toISOString(),
+            sha256: contentSha256,
+          },
+          links: {
+            download: buildAbsoluteUrl(request, `/file/${encodeURIComponent(existing.publicId)}`),
+            share: buildAbsoluteUrl(request, `/s/${encodeURIComponent(existing.publicId)}`),
+            delete: buildAbsoluteUrl(request, `/api/v1/file/${encodeURIComponent(existing.publicId)}`),
+          },
+          deduplicated: true,
+        };
+        if (idempotencyKey) {
+          try {
+            await env.img_url.put(idempotencyStoreKey(apiToken?.id, idempotencyKey), JSON.stringify({ status: 200, body: dedupBody, createdAt: Date.now() }), { expirationTtl: IDEMPOTENCY_TTL_SECONDS });
+          } catch { /* non-fatal */ }
+        }
+        return new Response(JSON.stringify(dedupBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+        });
+      }
+    } catch { /* dedup failures fall through to a normal upload */ }
   }
 
   const uploadForm = new FormData();
@@ -284,6 +405,18 @@ export async function onRequestPost(context) {
     ? (sanitizeSlug(metadata.shareSlug || '') || normalizedSlug)
     : '';
   const shareId = shareSlug || publicId;
+
+  await persistUploadSideEffects(env, apiToken, idempotencyKey, contentSha256, {
+    request,
+    publicId,
+    canonicalId,
+    fileName,
+    fileSize,
+    mime: mapMimeType(fileName, file.type || 'application/octet-stream'),
+    storageType: normalizeStorageType(canonicalId, metadata),
+    uploadedAt: uploadedAtValue,
+    shareId,
+  });
 
   return apiSuccess({
     file: {

--- a/functions/utils/api-token.js
+++ b/functions/utils/api-token.js
@@ -1,10 +1,46 @@
-const TOKEN_PREFIX = 'kvault_';
+/**
+ * API Token core (Cloudflare Pages / Workers KV).
+ *
+ * Storage model (requirement #2 — decoupled credential vs telemetry):
+ * - `api_token:<id>`  : credential record only. { id, name, scopes, enabled,
+ *                       expiresAt, createdAt, tokenSalt, tokenHash, tokenSuffix,
+ *                       tokenPreview, policies, rotatedAt }
+ *                       Telemetry writes NEVER touch this key, so an admin
+ *                       disable/scope-change can never be resurrected by a
+ *                       stale read-modify-write.
+ * - `token_stat:<id>` : telemetry only. { lastUsedAt, usageCount, lastSuccessAt,
+ *                       lastFailureAt, lastOperation, lastClient, lastTouchAt }
+ *                       lastUsedAt is sampled: at most one write per 60s.
+ * - `token_rl:<id>:<window>` : approximate per-token rate limit counters.
+ *
+ * Expiry semantics (requirement #8): API input accepts ISO-8601 strings or
+ * explicit `expiresAtMs`. Bare numeric expiresAt is rejected (INVALID_EXPIRY).
+ * Internal code always passes epoch milliseconds.
+ *
+ * Scope semantics (requirement #9): invalid scopes are rejected with 400
+ * INVALID_SCOPE + invalidScopes[], never silently filtered.
+ */
+
+export const TOKEN_PREFIX = 'kvault_';
 const TOKEN_KEY_PREFIX = 'api_token:';
+const STAT_KEY_PREFIX = 'token_stat:';
 const VALID_SCOPES = new Set(['upload', 'read', 'delete', 'paste']);
+export const VALID_STORAGES = ['telegram', 'r2', 's3', 'discord', 'huggingface', 'webdav', 'github'];
 const TOKEN_ID_LENGTH = 12;
 const TOKEN_SECRET_LENGTH = 40;
 const TOKEN_SALT_LENGTH = 16;
 const MASK_PREFIX = '******';
+const STAT_DEBOUNCE_MS = 60 * 1000;
+
+const MIME_PATTERN = /^[\w.+-]+\/[\w.+-]+$/;
+const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\.?$/;
+
+function tokenError(code, message, extra = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
 
 function timingSafeEqual(a, b) {
   if (a.length !== b.length) return false;
@@ -36,49 +72,161 @@ function splitToken(rawToken = '') {
   const value = String(rawToken || '').trim();
   const match = /^kvault_([A-Za-z0-9_-]{6,128})_([A-Za-z0-9_-]{16,256})$/.exec(value);
   if (!match) return null;
-  return {
-    tokenId: match[1],
-    secret: match[2],
-    value,
-  };
+  return { tokenId: match[1], secret: match[2], value };
 }
 
-function normalizeExpiresAt(rawValue) {
+/** Internal: epoch-ms sanity check. */
+function normalizeExpiryMs(rawValue) {
   if (rawValue == null || rawValue === '') return null;
+  const numeric = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  return Math.floor(numeric);
+}
+
+/**
+ * Public API input parsing (requirement #8).
+ * Accepts: ISO-8601 string | { expiresAtMs } explicit | null.
+ * Rejects bare numbers (unit ambiguity) and unparseable strings.
+ */
+export function parseExpiryInput(rawValue) {
+  if (rawValue == null || rawValue === '') return null;
+
   if (typeof rawValue === 'number') {
-    return Number.isFinite(rawValue) ? Math.max(0, Math.floor(rawValue)) : null;
+    throw tokenError('INVALID_EXPIRY', 'expiresAt must be an ISO-8601 string. Use expiresAtMs for epoch milliseconds.');
   }
+
+  if (typeof rawValue === 'object') {
+    if (Object.prototype.hasOwnProperty.call(rawValue, 'expiresAtMs')) {
+      const ms = normalizeExpiryMs(rawValue.expiresAtMs);
+      if (ms == null) {
+        throw tokenError('INVALID_EXPIRY', 'expiresAtMs must be a positive epoch-milliseconds number.');
+      }
+      return ms;
+    }
+    throw tokenError('INVALID_EXPIRY', 'Unsupported expiresAt payload.');
+  }
+
   const text = String(rawValue).trim();
   if (!text) return null;
-  const numeric = Number(text);
-  if (Number.isFinite(numeric)) {
-    return Math.max(0, Math.floor(numeric));
+
+  // Pure numeric strings are ambiguous (seconds vs ms) -> reject.
+  if (/^-?\d+$/.test(text)) {
+    throw tokenError('INVALID_EXPIRY', 'Bare numeric expiresAt is ambiguous. Send an ISO-8601 string or expiresAtMs.');
   }
+
   const parsed = Date.parse(text);
-  if (Number.isFinite(parsed)) {
-    return Math.max(0, Math.floor(parsed));
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw tokenError('INVALID_EXPIRY', `expiresAt "${text}" is not a valid ISO-8601 timestamp.`);
   }
-  return null;
+  return parsed;
 }
 
-function normalizeScopes(rawScopes = []) {
+/** Strict scope parsing (requirement #9): never silently filter. */
+export function parseScopesStrict(rawScopes = []) {
   const list = Array.isArray(rawScopes) ? rawScopes : [rawScopes];
   const normalized = [];
+  const invalidScopes = [];
   list.forEach((item) => {
     const scope = String(item || '').trim().toLowerCase();
-    if (!VALID_SCOPES.has(scope)) return;
-    if (normalized.includes(scope)) return;
-    normalized.push(scope);
+    if (!scope) return;
+    if (!VALID_SCOPES.has(scope)) {
+      if (!invalidScopes.includes(scope)) invalidScopes.push(scope);
+      return;
+    }
+    if (!normalized.includes(scope)) normalized.push(scope);
   });
+  if (invalidScopes.length > 0) {
+    throw tokenError('INVALID_SCOPE', `Unknown scopes: ${invalidScopes.join(', ')}.`, { invalidScopes });
+  }
+  if (normalized.length === 0) {
+    throw tokenError('INVALID_SCOPE', 'At least one valid scope is required.', { invalidScopes: [] });
+  }
   return normalized;
+}
+
+/** Per-token policies (requirement #10). Returns null when absent. */
+export function normalizePolicies(raw) {
+  if (raw == null || raw === '') return null;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw tokenError('INVALID_POLICY', 'policies must be an object.');
+  }
+
+  const out = {};
+
+  if (raw.allowedStorages != null) {
+    const list = (Array.isArray(raw.allowedStorages) ? raw.allowedStorages : [raw.allowedStorages])
+      .map((item) => String(item || '').trim().toLowerCase())
+      .filter(Boolean);
+    const invalid = list.filter((item) => !VALID_STORAGES.includes(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Unknown storage backend(s): ${invalid.join(', ')}.`, { invalidStorages: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedStorages = unique;
+  }
+
+  if (raw.allowedMimeTypes != null) {
+    const list = (Array.isArray(raw.allowedMimeTypes) ? raw.allowedMimeTypes : [raw.allowedMimeTypes])
+      .map((item) => String(item || '').trim().toLowerCase())
+      .filter(Boolean);
+    const invalid = list.filter((item) => !MIME_PATTERN.test(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Invalid MIME type(s): ${invalid.join(', ')}.`, { invalidMimeTypes: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedMimeTypes = unique;
+  }
+
+  if (raw.maxFileSize != null) {
+    const size = Number(raw.maxFileSize);
+    if (!Number.isFinite(size) || size <= 0 || size > 1024 * 1024 * 1024) {
+      throw tokenError('INVALID_POLICY', 'maxFileSize must be a positive number of bytes (max 1GiB).');
+    }
+    out.maxFileSize = Math.floor(size);
+  }
+
+  if (raw.folderPrefix != null) {
+    const prefix = String(raw.folderPrefix).replace(/\\/g, '/').trim().replace(/^\/+/, '');
+    if (prefix.includes('..')) {
+      throw tokenError('INVALID_POLICY', 'folderPrefix must not contain path traversal.');
+    }
+    if (prefix) out.folderPrefix = prefix.replace(/\/+$/, '');
+  }
+
+  if (raw.rateLimit != null) {
+    if (typeof raw.rateLimit !== 'object' || Array.isArray(raw.rateLimit)) {
+      throw tokenError('INVALID_POLICY', 'rateLimit must be an object { windowMs, max }.');
+    }
+    const windowMs = Number(raw.rateLimit.windowMs);
+    const max = Number(raw.rateLimit.max);
+    if (!Number.isFinite(windowMs) || windowMs < 1000 || windowMs > 24 * 3600 * 1000) {
+      throw tokenError('INVALID_POLICY', 'rateLimit.windowMs must be between 1000 and 86400000 ms.');
+    }
+    if (!Number.isFinite(max) || max < 1 || max > 100000) {
+      throw tokenError('INVALID_POLICY', 'rateLimit.max must be between 1 and 100000.');
+    }
+    out.rateLimit = { windowMs: Math.floor(windowMs), max: Math.floor(max) };
+  }
+
+  if (raw.allowedSourceHosts != null) {
+    const list = (Array.isArray(raw.allowedSourceHosts) ? raw.allowedSourceHosts : [raw.allowedSourceHosts])
+      .map((item) => String(item || '').trim().toLowerCase().replace(/\.$/, ''))
+      .filter(Boolean);
+    const invalid = list.filter((item) => !HOST_PATTERN.test(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Invalid source host(s): ${invalid.join(', ')}.`, { invalidHosts: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedSourceHosts = unique;
+  }
+
+  return Object.keys(out).length > 0 ? out : null;
 }
 
 async function sha256Hex(input) {
   const bytes = new TextEncoder().encode(String(input || ''));
   const digest = await crypto.subtle.digest('SHA-256', bytes);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
 async function hashTokenSecret(secret, salt) {
@@ -86,8 +234,7 @@ async function hashTokenSecret(secret, salt) {
 }
 
 function maskTokenSuffix(suffix = '') {
-  const normalized = String(suffix || '');
-  return `${MASK_PREFIX}${normalized}`;
+  return `${MASK_PREFIX}${String(suffix || '')}`;
 }
 
 function ensureKvBinding(env) {
@@ -96,48 +243,65 @@ function ensureKvBinding(env) {
   }
 }
 
-function toPublicRecord(record = {}) {
-  return {
-    id: record.id,
-    name: record.name,
-    scopes: Array.isArray(record.scopes) ? [...record.scopes] : [],
-    expiresAt: record.expiresAt ?? null,
-    createdAt: Number(record.createdAt || 0),
-    lastUsedAt: record.lastUsedAt ?? null,
-    enabled: Boolean(record.enabled),
-    tokenPreview: record.tokenPreview || maskTokenSuffix(record.tokenSuffix || ''),
-  };
+function credentialKey(tokenId) {
+  return `${TOKEN_KEY_PREFIX}${tokenId}`;
 }
 
-async function getRecordById(tokenId, env) {
+function statKey(tokenId) {
+  return `${STAT_KEY_PREFIX}${tokenId}`;
+}
+
+function normalizeRecordScopes(record) {
+  // Legacy records may contain scopes only; strict parse would throw on old
+  // garbage, so fall back to a filtered read for legacy data.
+  const scopes = Array.isArray(record.scopes) ? record.scopes : [];
+  return scopes.map((scope) => String(scope).trim().toLowerCase()).filter((scope) => VALID_SCOPES.has(scope));
+}
+
+async function getStat(tokenId, env) {
+  try {
+    const value = await env.img_url.get(statKey(tokenId), { type: 'json' });
+    if (!value || typeof value !== 'object') return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+export async function getRecordById(tokenId, env) {
   ensureKvBinding(env);
   const id = sanitizeTokenId(tokenId);
   if (!id) return null;
-  const value = await env.img_url.get(`${TOKEN_KEY_PREFIX}${id}`, { type: 'json' });
+  const value = await env.img_url.get(credentialKey(id), { type: 'json' });
   if (!value || typeof value !== 'object') return null;
   return {
     ...value,
     id,
-    scopes: normalizeScopes(value.scopes || []),
+    scopes: normalizeRecordScopes(value),
     enabled: value.enabled !== false,
-    expiresAt: normalizeExpiresAt(value.expiresAt),
+    expiresAt: normalizeExpiryMs(value.expiresAt),
     createdAt: Number(value.createdAt || 0),
-    lastUsedAt: value.lastUsedAt == null ? null : Number(value.lastUsedAt || 0),
+    policies: normalizeStoredPolicies(value.policies),
+    rotatedAt: value.rotatedAt == null ? null : Number(value.rotatedAt || 0),
   };
+}
+
+function normalizeStoredPolicies(raw) {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  // Stored policies were validated at write time; trust shape but copy.
+  return { ...raw };
 }
 
 async function putRecord(record, env) {
   ensureKvBinding(env);
-  await env.img_url.put(`${TOKEN_KEY_PREFIX}${record.id}`, JSON.stringify(record));
+  await env.img_url.put(credentialKey(record.id), JSON.stringify(record));
 }
 
 async function generateUniqueTokenId(env, maxAttempts = 10) {
   for (let i = 0; i < maxAttempts; i += 1) {
     const candidate = randomString(TOKEN_ID_LENGTH);
-    const exists = await env.img_url.get(`${TOKEN_KEY_PREFIX}${candidate}`);
-    if (exists == null) {
-      return candidate;
-    }
+    const exists = await env.img_url.get(credentialKey(candidate));
+    if (exists == null) return candidate;
   }
   throw new Error('Failed to generate a unique token id.');
 }
@@ -154,18 +318,18 @@ export function parseBearerToken(request) {
   return String(match[1] || '').trim();
 }
 
-export async function createApiToken({ name, scopes, expiresAt, enabled = true }, env) {
+export async function createApiToken({ name, scopes, expiresAt, policies, enabled = true }, env) {
   ensureKvBinding(env);
 
   const normalizedName = String(name || '').trim();
   if (!normalizedName) {
-    throw new Error('Token name is required.');
+    throw tokenError('VALIDATION_ERROR', 'Token name is required.');
   }
 
-  const normalizedScopes = normalizeScopes(scopes);
-  if (normalizedScopes.length === 0) {
-    throw new Error('At least one valid scope is required.');
-  }
+  const normalizedScopes = parseScopesStrict(scopes);
+  // expiresAt here is already epoch-ms (route layer parses user input first).
+  const expiryMs = normalizeExpiryMs(expiresAt);
+  const normalizedPolicies = normalizePolicies(policies);
 
   const tokenId = await generateUniqueTokenId(env);
   const tokenSecret = randomString(TOKEN_SECRET_LENGTH);
@@ -178,10 +342,11 @@ export async function createApiToken({ name, scopes, expiresAt, enabled = true }
     id: tokenId,
     name: normalizedName,
     scopes: normalizedScopes,
-    expiresAt: normalizeExpiresAt(expiresAt),
+    expiresAt: expiryMs,
     createdAt: now,
-    lastUsedAt: null,
     enabled: enabled !== false,
+    policies: normalizedPolicies,
+    rotatedAt: null,
     tokenSalt,
     tokenHash,
     tokenSuffix,
@@ -192,7 +357,7 @@ export async function createApiToken({ name, scopes, expiresAt, enabled = true }
 
   return {
     token: `${TOKEN_PREFIX}${tokenId}_${tokenSecret}`,
-    record: toPublicRecord(record),
+    record: toPublicRecord(record, null),
   };
 }
 
@@ -200,15 +365,10 @@ export async function listApiTokens(env) {
   ensureKvBinding(env);
 
   const keys = [];
-  let cursor = undefined;
+  let cursor;
   let guard = 0;
-
   do {
-    const page = await env.img_url.list({
-      prefix: TOKEN_KEY_PREFIX,
-      limit: 1000,
-      cursor,
-    });
+    const page = await env.img_url.list({ prefix: TOKEN_KEY_PREFIX, limit: 1000, cursor });
     keys.push(...(page.keys || []).map((item) => item.name));
     cursor = page.list_complete ? undefined : page.cursor;
     guard += 1;
@@ -217,14 +377,16 @@ export async function listApiTokens(env) {
   const records = await Promise.all(
     keys.map(async (key) => {
       const id = key.slice(TOKEN_KEY_PREFIX.length);
-      return getRecordById(id, env);
+      const record = await getRecordById(id, env);
+      if (!record) return null;
+      const stat = await getStat(id, env);
+      return toPublicRecord(record, stat);
     })
   );
 
   return records
     .filter(Boolean)
-    .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0))
-    .map((record) => toPublicRecord(record));
+    .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0));
 }
 
 export async function updateApiToken(tokenId, patch = {}, env) {
@@ -232,6 +394,7 @@ export async function updateApiToken(tokenId, patch = {}, env) {
   if (!record) return null;
 
   const next = { ...record };
+  const auditExtras = {};
 
   if (Object.prototype.hasOwnProperty.call(patch, 'enabled')) {
     next.enabled = Boolean(patch.enabled);
@@ -240,25 +403,26 @@ export async function updateApiToken(tokenId, patch = {}, env) {
   if (Object.prototype.hasOwnProperty.call(patch, 'name')) {
     const normalizedName = String(patch.name || '').trim();
     if (!normalizedName) {
-      throw new Error('Token name is required.');
+      throw tokenError('VALIDATION_ERROR', 'Token name is required.');
     }
     next.name = normalizedName;
   }
 
   if (Object.prototype.hasOwnProperty.call(patch, 'scopes')) {
-    const normalizedScopes = normalizeScopes(patch.scopes);
-    if (normalizedScopes.length === 0) {
-      throw new Error('At least one valid scope is required.');
-    }
-    next.scopes = normalizedScopes;
+    next.scopes = parseScopesStrict(patch.scopes);
+    auditExtras.scopes = [...next.scopes];
   }
 
   if (Object.prototype.hasOwnProperty.call(patch, 'expiresAt')) {
-    next.expiresAt = normalizeExpiresAt(patch.expiresAt);
+    next.expiresAt = normalizeExpiryMs(patch.expiresAt);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'policies')) {
+    next.policies = normalizePolicies(patch.policies);
   }
 
   await putRecord(next, env);
-  return toPublicRecord(next);
+  return { record: toPublicRecord(next, await getStat(record.id, env)), auditExtras };
 }
 
 export async function deleteApiToken(tokenId, env) {
@@ -267,69 +431,106 @@ export async function deleteApiToken(tokenId, env) {
   if (!id) return false;
   const existing = await getRecordById(id, env);
   if (!existing) return false;
-  await env.img_url.delete(`${TOKEN_KEY_PREFIX}${id}`);
+  await env.img_url.delete(credentialKey(id));
+  await env.img_url.delete(statKey(id)).catch(() => {});
   return true;
 }
 
-export async function touchApiTokenLastUsed(tokenId, env) {
+/**
+ * Rotate a token (requirement #7): new secret, same identity/scopes/policies.
+ * The old secret stops working immediately because the stored hash changes.
+ */
+export async function rotateApiToken(tokenId, env) {
   const record = await getRecordById(tokenId, env);
-  if (!record) return false;
-  record.lastUsedAt = Date.now();
-  await putRecord(record, env);
-  return true;
+  if (!record) return null;
+
+  const tokenSecret = randomString(TOKEN_SECRET_LENGTH);
+  const tokenSalt = randomString(TOKEN_SALT_LENGTH);
+  const tokenHash = await hashTokenSecret(tokenSecret, tokenSalt);
+  const tokenSuffix = tokenSecret.slice(-6);
+
+  const next = {
+    ...record,
+    tokenSalt,
+    tokenHash,
+    tokenSuffix,
+    tokenPreview: maskTokenSuffix(tokenSuffix),
+    rotatedAt: Date.now(),
+  };
+
+  await putRecord(next, env);
+  return {
+    token: `${TOKEN_PREFIX}${next.id}_${tokenSecret}`,
+    record: toPublicRecord(next, await getStat(next.id, env)),
+  };
 }
 
+/**
+ * Telemetry write (requirement #2). Writes ONLY the stat key with a 60s
+ * sample debounce. Never touches the credential record.
+ */
+export async function touchApiTokenUsage(tokenId, env, { success = true, operation = '', client = '' } = {}) {
+  try {
+    ensureKvBinding(env);
+    const id = sanitizeTokenId(tokenId);
+    if (!id) return false;
+
+    const now = Date.now();
+    const stat = (await getStat(id, env)) || {};
+
+    if (Number(stat.lastTouchAt || 0) > 0 && now - Number(stat.lastTouchAt || 0) < STAT_DEBOUNCE_MS) {
+      return false; // sampled: skip write inside the debounce window
+    }
+
+    const next = {
+      lastUsedAt: now,
+      usageCount: Number(stat.usageCount || 0) + 1,
+      lastSuccessAt: success ? now : Number(stat.lastSuccessAt || 0) || null,
+      lastFailureAt: success ? Number(stat.lastFailureAt || 0) || null : now,
+      lastOperation: String(operation || stat.lastOperation || '').slice(0, 64) || null,
+      lastClient: String(client || stat.lastClient || '').slice(0, 80) || null,
+      lastTouchAt: now,
+    };
+
+    await env.img_url.put(statKey(id), JSON.stringify(next));
+    return true;
+  } catch (error) {
+    console.warn('Failed to update API token usage stats:', error?.message || error);
+    return false;
+  }
+}
+
+/**
+ * Verify a bearer token. Pure read: this function never writes KV, so it can
+ * never resurrect a disabled token or stale scopes (requirement #2).
+ * requiredScope === '@me' means "any valid token" (introspection endpoint).
+ */
 export async function verifyApiToken(tokenValue, env, requiredScope = '') {
   const split = splitToken(tokenValue);
   if (!split) {
-    return {
-      ok: false,
-      status: 401,
-      code: 'TOKEN_INVALID',
-      message: 'API Token is invalid.',
-    };
+    return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
   }
 
   const record = await getRecordById(split.tokenId, env);
   if (!record) {
-    return {
-      ok: false,
-      status: 401,
-      code: 'TOKEN_INVALID',
-      message: 'API Token is invalid.',
-    };
+    return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
   }
 
   const expectedHash = await hashTokenSecret(split.secret, record.tokenSalt || '');
   if (!timingSafeEqual(expectedHash, String(record.tokenHash || ''))) {
-    return {
-      ok: false,
-      status: 401,
-      code: 'TOKEN_INVALID',
-      message: 'API Token is invalid.',
-    };
+    return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
   }
 
   if (!record.enabled) {
-    return {
-      ok: false,
-      status: 401,
-      code: 'TOKEN_DISABLED',
-      message: 'API Token is disabled.',
-    };
+    return { ok: false, status: 401, code: 'TOKEN_DISABLED', message: 'API Token is disabled.' };
   }
 
   if (Number.isFinite(record.expiresAt) && record.expiresAt > 0 && Date.now() > record.expiresAt) {
-    return {
-      ok: false,
-      status: 401,
-      code: 'TOKEN_EXPIRED',
-      message: 'API Token has expired.',
-    };
+    return { ok: false, status: 401, code: 'TOKEN_EXPIRED', message: 'API Token has expired.' };
   }
 
   const normalizedScope = String(requiredScope || '').trim().toLowerCase();
-  if (normalizedScope && !record.scopes.includes(normalizedScope)) {
+  if (normalizedScope && normalizedScope !== '@me' && !record.scopes.includes(normalizedScope)) {
     return {
       ok: false,
       status: 403,
@@ -338,8 +539,62 @@ export async function verifyApiToken(tokenValue, env, requiredScope = '') {
     };
   }
 
+  return { ok: true, token: record };
+}
+
+function toPublicRecord(record, stat = null) {
+  const legacyLastUsed = record.lastUsedAt == null ? null : Number(record.lastUsedAt || 0);
   return {
-    ok: true,
-    token: toPublicRecord(record),
+    id: record.id,
+    name: record.name,
+    scopes: Array.isArray(record.scopes) ? [...record.scopes] : [],
+    expiresAt: record.expiresAt ?? null,
+    createdAt: Number(record.createdAt || 0),
+    lastUsedAt: stat?.lastUsedAt != null ? Number(stat.lastUsedAt) : legacyLastUsed,
+    usageCount: stat?.usageCount != null ? Number(stat.usageCount) : 0,
+    lastOperation: stat?.lastOperation ?? null,
+    lastClient: stat?.lastClient ?? null,
+    enabled: Boolean(record.enabled),
+    policies: record.policies ? { ...record.policies } : null,
+    rotatedAt: record.rotatedAt == null ? null : Number(record.rotatedAt || 0),
+    tokenPreview: record.tokenPreview || maskTokenSuffix(record.tokenSuffix || ''),
   };
+}
+
+/**
+ * Approximate per-token rate limit (requirement #10). KV has no atomic
+ * counters, so counts can drift under races; acceptable for throttling.
+ * Returns { allowed: true } or { allowed: false, retryAfterMs }.
+ */
+export async function checkTokenRateLimit(record, env) {
+  const policy = record?.policies?.rateLimit;
+  if (!policy) return { allowed: true };
+  ensureKvBinding(env);
+
+  const now = Date.now();
+  const windowStart = Math.floor(now / policy.windowMs) * policy.windowMs;
+  const key = `token_rl:${record.id}:${windowStart}`;
+  const retryAfterMs = windowStart + policy.windowMs - now;
+
+  let count = 0;
+  try {
+    const raw = await env.img_url.get(key, { type: 'json' });
+    count = Number(raw?.count || 0);
+  } catch {
+    count = 0;
+  }
+
+  if (count >= policy.max) {
+    return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 1) };
+  }
+
+  try {
+    await env.img_url.put(key, JSON.stringify({ count: count + 1 }), {
+      expirationTtl: Math.max(Math.ceil(policy.windowMs / 1000) + 5, 10),
+    });
+  } catch (error) {
+    console.warn('Rate limit counter write failed:', error?.message || error);
+  }
+
+  return { allowed: true };
 }

--- a/functions/utils/api-v1.js
+++ b/functions/utils/api-v1.js
@@ -66,3 +66,58 @@ export function buildAbsoluteUrl(request, path) {
   const normalizedPath = String(path || '').startsWith('/') ? String(path) : `/${String(path || '')}`;
   return `${origin}${normalizedPath}`;
 }
+
+/**
+ * Map a thrown token/validation error to a proper API error response.
+ * Used by admin token routes for strict INVALID_SCOPE / INVALID_EXPIRY /
+ * INVALID_POLICY handling (requirements #8, #9, #10).
+ */
+export function tokenErrorResponse(error, fallbackCode = 'TOKEN_OPERATION_FAILED', fallbackStatus = 400) {
+  const code = String(error?.code || '');
+  if (code === 'INVALID_SCOPE') {
+    return apiError('INVALID_SCOPE', error.message || 'Invalid scopes.', 400, {
+      invalidScopes: Array.isArray(error.invalidScopes) ? error.invalidScopes : [],
+    });
+  }
+  if (code === 'INVALID_EXPIRY') {
+    return apiError('INVALID_EXPIRY', error.message || 'Invalid expiry.', 400);
+  }
+  if (code === 'INVALID_POLICY') {
+    return apiError('INVALID_POLICY', error.message || 'Invalid policies.', 400, {
+      invalidStorages: Array.isArray(error.invalidStorages) ? error.invalidStorages : undefined,
+      invalidMimeTypes: Array.isArray(error.invalidMimeTypes) ? error.invalidMimeTypes : undefined,
+      invalidHosts: Array.isArray(error.invalidHosts) ? error.invalidHosts : undefined,
+    });
+  }
+  if (code === 'VALIDATION_ERROR') {
+    return apiError('VALIDATION_ERROR', error.message || 'Validation failed.', 400);
+  }
+  return apiError(fallbackCode, error?.message || 'Token operation failed.', fallbackStatus);
+}
+
+/**
+ * Parse user-facing expiry input for token create/update.
+ * Supports ISO-8601 strings, expiresAtMs, expiresIn/expires_in (seconds) and
+ * expiresInDays. Bare numeric expiresAt throws INVALID_EXPIRY.
+ */
+export function parseTokenExpiryFromBody(body = {}) {
+  if (Object.prototype.hasOwnProperty.call(body, 'expiresAtMs')) {
+    return { kind: 'expiresAtMs', value: body.expiresAtMs };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
+    return { kind: 'iso', value: body.expiresAt };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'expires_in')) {
+    const seconds = parsePositiveInt(body.expires_in, { defaultValue: 0, min: 1, max: 3650 * 24 * 3600 });
+    return { kind: 'ms', value: seconds > 0 ? Date.now() + seconds * 1000 : null };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'expiresIn')) {
+    const seconds = parsePositiveInt(body.expiresIn, { defaultValue: 0, min: 1, max: 3650 * 24 * 3600 });
+    return { kind: 'ms', value: seconds > 0 ? Date.now() + seconds * 1000 : null };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, 'expiresInDays')) {
+    const days = parsePositiveInt(body.expiresInDays, { defaultValue: 0, min: 1, max: 3650 });
+    return { kind: 'ms', value: days > 0 ? Date.now() + days * 24 * 3600 * 1000 : null };
+  }
+  return { kind: 'none', value: null };
+}

--- a/functions/utils/audit.js
+++ b/functions/utils/audit.js
@@ -1,0 +1,78 @@
+/**
+ * Audit log for token management events (requirement #12).
+ *
+ * Events: TOKEN_CREATED, TOKEN_ROTATED, TOKEN_DISABLED, TOKEN_ENABLED,
+ *         TOKEN_SCOPE_CHANGED, TOKEN_DELETED, TOKEN_VERIFY_FAILED
+ *
+ * - Never records full token secrets (redaction applied to detail).
+ * - No IP addresses are stored; only a short client tag is kept.
+ * - Records live in KV under `audit:<ts>:<rand>` with 180-day TTL.
+ * - Audit failures must never break the main request flow.
+ */
+
+import { redactSecrets } from './redact.js';
+
+const AUDIT_TTL_SECONDS = 180 * 24 * 3600;
+
+function shortRandom() {
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export const AUDIT_EVENTS = {
+  TOKEN_CREATED: 'TOKEN_CREATED',
+  TOKEN_ROTATED: 'TOKEN_ROTATED',
+  TOKEN_DISABLED: 'TOKEN_DISABLED',
+  TOKEN_ENABLED: 'TOKEN_ENABLED',
+  TOKEN_SCOPE_CHANGED: 'TOKEN_SCOPE_CHANGED',
+  TOKEN_DELETED: 'TOKEN_DELETED',
+  TOKEN_VERIFY_FAILED: 'TOKEN_VERIFY_FAILED',
+};
+
+export async function writeAuditLog(env, entry = {}) {
+  try {
+    if (!env?.img_url) return false;
+    const record = {
+      event: String(entry.event || 'UNKNOWN').slice(0, 64),
+      tokenId: String(entry.tokenId || '').slice(0, 128) || null,
+      operation: String(entry.operation || '').slice(0, 64) || null,
+      timestamp: Date.now(),
+      success: entry.success !== false,
+      client: String(entry.client || '').slice(0, 80) || null,
+      detail: entry.detail == null ? null : redactSecrets(String(entry.detail)).slice(0, 500),
+    };
+    const key = `audit:${Date.now().toString(36)}:${shortRandom()}`;
+    await env.img_url.put(key, JSON.stringify(record), {
+      expirationTtl: AUDIT_TTL_SECONDS,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Audit log write failed:', error?.message || error);
+    return false;
+  }
+}
+
+export async function listAuditLogs(env, { limit = 100 } = {}) {
+  if (!env?.img_url) return [];
+  const keys = [];
+  let cursor;
+  let guard = 0;
+  do {
+    const page = await env.img_url.list({ prefix: 'audit:', limit: 1000, cursor });
+    keys.push(...(page.keys || []).map((item) => item.name));
+    cursor = page.list_complete ? undefined : page.cursor;
+    guard += 1;
+  } while (cursor && guard < 100);
+
+  const records = await Promise.all(
+    keys.slice(-limit).map(async (key) => {
+      try {
+        return await env.img_url.get(key, { type: 'json' });
+      } catch {
+        return null;
+      }
+    })
+  );
+  return records.filter(Boolean).sort((a, b) => Number(b.timestamp || 0) - Number(a.timestamp || 0));
+}

--- a/functions/utils/cors.js
+++ b/functions/utils/cors.js
@@ -1,0 +1,52 @@
+/**
+ * Unified API CORS (requirement #3).
+ *
+ * - API_CORS_ORIGINS: comma-separated origin whitelist. "*" allows any origin
+ *   (without credentials). Unset/empty = same-origin only (no ACAO header).
+ * - Preflight OPTIONS always answers 204 without requiring a Bearer token.
+ * - /api/admin/** is never opened for cross-origin access.
+ */
+
+const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+const ALLOWED_HEADERS = 'Authorization, Content-Type, Accept, Range, Idempotency-Key, X-KVault-Client';
+const MAX_AGE = '86400';
+
+export function parseCorsOrigins(env) {
+  const raw = String(env?.API_CORS_ORIGINS || '').trim();
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function resolveCorsHeaders(request, env) {
+  const headers = {
+    Vary: 'Origin',
+    'Access-Control-Allow-Methods': ALLOWED_METHODS,
+    'Access-Control-Allow-Headers': ALLOWED_HEADERS,
+    'Access-Control-Max-Age': MAX_AGE,
+  };
+
+  const origin = String(request.headers.get('Origin') || '').trim();
+  if (!origin) return headers;
+
+  const whitelist = parseCorsOrigins(env);
+  if (whitelist.includes('*')) {
+    headers['Access-Control-Allow-Origin'] = '*';
+    return headers;
+  }
+  if (whitelist.includes(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+    return headers;
+  }
+  // Origin not whitelisted: no ACAO header -> browser blocks the response.
+  return headers;
+}
+
+export function handleApiPreflight(request, env) {
+  return new Response(null, {
+    status: 204,
+    headers: resolveCorsHeaders(request, env),
+  });
+}

--- a/functions/utils/policy-enforce.js
+++ b/functions/utils/policy-enforce.js
@@ -1,0 +1,80 @@
+/**
+ * Per-token policy enforcement (requirement #10).
+ * Shared by /api/v1/upload and /api/v1/import.
+ */
+
+function baseMime(mime) {
+  return String(mime || '').split(';')[0].trim().toLowerCase();
+}
+
+export function checkUploadPolicy(tokenRecord, { storage, mime, sizeBytes, folderPath, request }) {
+  const policies = tokenRecord?.policies;
+  if (!policies) return { ok: true };
+
+  if (policies.allowedStorages?.length) {
+    if (!storage || !policies.allowedStorages.includes(storage)) {
+      return {
+        ok: false,
+        status: 403,
+        code: 'POLICY_STORAGE_DENIED',
+        message: `API Token policy only allows storage: ${policies.allowedStorages.join(', ')}.`,
+      };
+    }
+  }
+
+  if (policies.allowedMimeTypes?.length) {
+    const normalized = baseMime(mime);
+    if (!normalized || !policies.allowedMimeTypes.includes(normalized)) {
+      return {
+        ok: false,
+        status: 403,
+        code: 'POLICY_MIME_DENIED',
+        message: `API Token policy only allows MIME types: ${policies.allowedMimeTypes.join(', ')}.`,
+      };
+    }
+  }
+
+  if (policies.maxFileSize && Number(sizeBytes) > policies.maxFileSize) {
+    return {
+      ok: false,
+      status: 413,
+      code: 'POLICY_SIZE_EXCEEDED',
+      message: `API Token policy limits uploads to ${policies.maxFileSize} bytes.`,
+    };
+  }
+
+  if (policies.folderPrefix) {
+    const folder = String(folderPath || '').replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!folder.startsWith(policies.folderPrefix)) {
+      return {
+        ok: false,
+        status: 403,
+        code: 'POLICY_FOLDER_DENIED',
+        message: `API Token policy restricts uploads to folder prefix "${policies.folderPrefix}/".`,
+      };
+    }
+  }
+
+  if (policies.allowedSourceHosts?.length) {
+    const origin = String(request?.headers?.get('Origin') || request?.headers?.get('Referer') || '').trim();
+    if (origin) {
+      try {
+        const host = new URL(origin).host.toLowerCase();
+        if (!policies.allowedSourceHosts.includes(host)) {
+          return {
+            ok: false,
+            status: 403,
+            code: 'POLICY_SOURCE_DENIED',
+            message: `API Token policy only allows source hosts: ${policies.allowedSourceHosts.join(', ')}.`,
+          };
+        }
+      } catch {
+        return { ok: false, status: 403, code: 'POLICY_SOURCE_DENIED', message: 'Invalid Origin/Referer header.' };
+      }
+    }
+    // No Origin/Referer (server-to-server calls) -> allowed; browser clients
+    // always send one of them on cross-origin requests.
+  }
+
+  return { ok: true };
+}

--- a/functions/utils/redact.js
+++ b/functions/utils/redact.js
@@ -1,0 +1,29 @@
+/**
+ * Secret redaction helpers (requirement #13).
+ * Ensures full API Token secrets never leak into logs, error messages,
+ * audit records or console output.
+ */
+
+const TOKEN_PATTERN = /kvault_[A-Za-z0-9_-]{6,}/g;
+const REDACTED = 'kvault_***REDACTED***';
+
+export function redactSecrets(input) {
+  if (typeof input !== 'string') return input;
+  return input.replace(TOKEN_PATTERN, REDACTED);
+}
+
+export function redactErrorMessage(error) {
+  if (error == null) return '';
+  const message = typeof error === 'string' ? error : String(error?.message || error);
+  return redactSecrets(message);
+}
+
+export function safeLogError(error, ...rest) {
+  try {
+    console.error(redactErrorMessage(error), ...rest.map((item) => (
+      typeof item === 'string' ? redactSecrets(item) : item
+    )));
+  } catch {
+    // logging must never throw
+  }
+}

--- a/functions/utils/ssrf-guard.js
+++ b/functions/utils/ssrf-guard.js
@@ -1,0 +1,143 @@
+/**
+ * SSRF guard for remote URL imports (requirement #6).
+ *
+ * Cloudflare Workers cannot perform custom DNS resolution, so this guard
+ * enforces hostname-literal and protocol rules. Docker uses the Node variant
+ * (server/lib/utils/ssrf-guard.js) which additionally resolves DNS and checks
+ * every resolved IP. Redirects must be re-validated on every hop by callers.
+ */
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'metadata',
+  'metadata.google.internal',
+  'instance-data',
+  'instance-data.internal',
+]);
+
+function ipv4ToInt(host) {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    value = value * 256 + octet;
+  }
+  return value;
+}
+
+function isPrivateIPv4(host) {
+  const value = ipv4ToInt(host);
+  if (value == null) return false;
+  const a = (value / 16777216) | 0;               // first octet
+  const second = (value / 65536) | 0;
+  const b = second % 256;                         // second octet
+  if (a === 0) return true;                       // 0.0.0.0/8 "this network"
+  if (a === 10) return true;                      // RFC1918 10/8
+  if (a === 127) return true;                     // loopback
+  if (a === 169 && b === 254) return true;        // link-local + AWS/GCP metadata
+  if (a === 172 && (b >= 16 && b <= 31)) return true; // RFC1918 172.16/12
+  if (a === 192 && b === 168) return true;        // RFC1918 192.168/16
+  if (a === 100 && (b >= 64 && b <= 127)) return true; // CGNAT 100.64/10
+  if (a >= 224) return true;                      // multicast + reserved
+  return false;
+}
+
+function isPrivateIPv6(host) {
+  const value = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (value === '::' || value === '::1') return true;
+  if (value.startsWith('fe80')) return true;      // link-local
+  if (value.startsWith('fc') || value.startsWith('fd')) return true; // ULA fc00::/7
+  if (value.startsWith('fec') || value.startsWith('fed') || value.startsWith('fee') || value.startsWith('fef')) return true;
+  if (value.startsWith('fd00:ec2:')) return true; // AWS IPv6 metadata
+  if (value.startsWith('::ffff:')) {
+    const mapped = value.slice(7);
+    if (mapped.includes('.')) return isPrivateIPv4(mapped);
+  }
+  return false;
+}
+
+export function isPrivateHost(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (BLOCKED_HOSTNAMES.has(host)) return true;
+  if (host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) return true;
+  if (isPrivateIPv4(host)) return true;
+  if (host.includes(':')) return isPrivateIPv6(host);
+  return false;
+}
+
+/**
+ * Validate an https? URL for remote import.
+ * Returns { ok: true, url } or { ok: false, code, message }.
+ */
+export function validateRemoteUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(String(rawUrl || '').trim());
+  } catch {
+    return { ok: false, code: 'INVALID_URL', message: 'Invalid URL.' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, code: 'INVALID_URL', message: 'Only http/https URLs are allowed.' };
+  }
+
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (!hostname) {
+    return { ok: false, code: 'INVALID_URL', message: 'URL has no hostname.' };
+  }
+  if (isPrivateHost(hostname)) {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Requests to private, loopback or metadata addresses are blocked.' };
+  }
+
+  const port = parsed.port ? Number(parsed.port) : (parsed.protocol === 'https:' ? 443 : 80);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    return { ok: false, code: 'INVALID_URL', message: 'Invalid port.' };
+  }
+  if (port !== 80 && port !== 443 && port !== 8080 && port !== 8443) {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Only ports 80, 443, 8080 and 8443 are allowed for remote import.' };
+  }
+
+  return { ok: true, url: parsed };
+}
+
+export const MAX_REDIRECTS = 5;
+
+/**
+ * Resolve a redirect target and re-validate it (call for every hop).
+ */
+export function validateRedirectLocation(location, previousUrl) {
+  let next;
+  try {
+    next = new URL(String(location || ''), previousUrl);
+  } catch {
+    return { ok: false, code: 'INVALID_REDIRECT', message: 'Invalid redirect location.' };
+  }
+  if (next.protocol !== 'http:' && next.protocol !== 'https:') {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Redirects to non-http(s) protocols are blocked.' };
+  }
+  const check = validateRemoteUrl(next.href);
+  if (!check.ok) return check;
+  return { ok: true, url: next };
+}
+
+/** Sniff image MIME from magic bytes (requirement: never trust Content-Type alone). */
+export function sniffImageMime(bytes) {
+  if (!bytes || bytes.length < 12) return null;
+  const b = bytes;
+  const startsWith = (arr, offset = 0) => arr.every((byte, index) => b[offset + index] === byte);
+
+  if (startsWith([0xff, 0xd8, 0xff])) return 'image/jpeg';
+  if (startsWith([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return 'image/png';
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && startsWith([0x57, 0x45, 0x42, 0x50], 8)) return 'image/webp';
+  if (startsWith([0x66, 0x74, 0x79, 0x70], 4) && startsWith([0x61, 0x76, 0x69, 0x66], 8)) return 'image/avif';
+  if (startsWith([0x47, 0x49, 0x46, 0x38])) return 'image/gif';
+  if (startsWith([0x42, 0x4d])) return 'image/bmp';
+  if (startsWith([0x00, 0x00, 0x01, 0x00])) return 'image/x-icon';
+  return null;
+}

--- a/scripts/docker-ci-smoke.js
+++ b/scripts/docker-ci-smoke.js
@@ -40,7 +40,7 @@ function sleepMs(ms) {
 
 function waitForApi(maxAttempts = 60, intervalMs = 2000) {
   for (let i = 0; i < maxAttempts; i += 1) {
-    const health = runComposeExec('wget -qO- http://localhost:8080/api/health');
+    const health = runComposeExec('wget -qO- http://127.0.0.1:8080/api/health');
     if (health.code === 0) {
       return true;
     }
@@ -49,8 +49,24 @@ function waitForApi(maxAttempts = 60, intervalMs = 2000) {
   return false;
 }
 
+function dumpSmokeDiagnostics() {
+  const sections = [
+    ['listeners (netstat -tln / /proc/net/tcp)', 'netstat -tln 2>/dev/null || cat /proc/net/tcp'],
+    ['processes', 'ps w 2>/dev/null || true'],
+    ['wget nginx :8080/api/health', 'wget -qO- -S -T 5 http://127.0.0.1:8080/api/health 2>&1 || true'],
+    ['wget node :8787/api/health', 'wget -qO- -S -T 5 http://127.0.0.1:8787/api/health 2>&1 || true'],
+    ['nginx config test', 'nginx -t 2>&1 || true'],
+  ];
+  for (const [label, script] of sections) {
+    const result = runComposeExec(script);
+    process.stderr.write(`--- smoke diagnostics: ${label} (exit=${result.code}) ---\n`);
+    if (result.stdout) process.stderr.write(result.stdout + '\n');
+    if (result.stderr) process.stderr.write(result.stderr + '\n');
+  }
+}
+
 function readStatus() {
-  const response = runComposeExec('wget -qO- http://localhost:8080/api/status');
+  const response = runComposeExec('wget -qO- http://127.0.0.1:8080/api/status');
   if (response.code !== 0) {
     return { ok: false, error: response.stderr || response.stdout || 'status request failed', data: null };
   }
@@ -79,7 +95,7 @@ function readProfileTypes() {
 }
 
 function readPublicText(pathname) {
-  const response = runComposeExec(`wget -qO- http://localhost:8080${pathname}`);
+  const response = runComposeExec(`wget -qO- http://127.0.0.1:8080${pathname}`);
   if (response.code !== 0) {
     return { ok: false, error: response.stderr || response.stdout || `${pathname} request failed`, text: '' };
   }
@@ -108,6 +124,7 @@ function main() {
   }
 
   if (!waitForApi()) {
+    dumpSmokeDiagnostics();
     process.stderr.write('API did not become ready in time.\n');
     process.exit(2);
     return;

--- a/server/app.js
+++ b/server/app.js
@@ -7,9 +7,21 @@ const { createContainer } = require('./lib/container');
 const { normalizeFolderPath } = require('./lib/repos/file-repo');
 const {
   getApiTokenScopes,
-  normalizeExpiresAt,
   parseBearerToken,
+  parseExpiryInput,
+  parseScopesStrict,
+  normalizePolicies,
+  VALID_STORAGES,
 } = require('./lib/repos/api-token-repo');
+const { run: dbRun, get: dbGet } = require('./db');
+const {
+  assertSafeRemoteUrl,
+  validateRedirectLocation,
+  sniffImageMime,
+  MAX_REDIRECTS,
+} = require('./lib/utils/ssrf-guard');
+const { AUDIT_EVENTS, writeAuditLog, listAuditLogs } = require('./lib/utils/audit');
+const { safeLogError } = require('./lib/utils/redact');
 const { toStorageErrorPayload } = require('./lib/utils/storage-error');
 const { createShareSignature, verifyShareSignature } = require('./lib/utils/share-link');
 const {
@@ -29,13 +41,41 @@ function createApp() {
   const app = new Hono();
   const container = createContainer(process.env);
 
-  app.use('*', cors({
-    origin: (origin) => origin || '*',
-    allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'Authorization', 'Range', 'X-KVault-Client', 'Accept'],
-    exposeHeaders: ['Content-Length', 'Content-Range', 'Accept-Ranges', 'Content-Disposition'],
-    credentials: true,
-  }));
+  const corsAllowedOrigins = String(process.env.API_CORS_ORIGINS || '')
+    .split(/[\s,]+/)
+    .map((item) => item.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+  const corsAllowHeaders = 'Content-Type, Authorization, Accept, Range, Idempotency-Key, X-KVault-Client';
+
+  function originAllowed(origin) {
+    if (!origin) return false;
+    return corsAllowedOrigins.includes(origin.replace(/\/+$/, ''));
+  }
+
+  // Requirement #3: unified API CORS with an allow-list (API_CORS_ORIGINS).
+  // Unlisted origins get no CORS headers. Preflight (OPTIONS) never requires
+  // a Bearer token and always answers 204 with Vary: Origin.
+  app.use('/api/*', async (c, next) => {
+    const origin = c.req.header('Origin') || '';
+    if (c.req.method === 'OPTIONS') {
+      const response = new Response(null, { status: 204 });
+      response.headers.set('Vary', 'Origin');
+      response.headers.set('Access-Control-Max-Age', '86400');
+      if (originAllowed(origin)) {
+        response.headers.set('Access-Control-Allow-Origin', origin);
+        response.headers.set('Access-Control-Allow-Credentials', 'true');
+        response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
+        response.headers.set('Access-Control-Allow-Headers', c.req.header('Access-Control-Request-Headers') || corsAllowHeaders);
+      }
+      return response;
+    }
+    await next();
+    if (originAllowed(origin) && c.res) {
+      c.res.headers.set('Access-Control-Allow-Origin', origin);
+      c.res.headers.set('Access-Control-Allow-Credentials', 'true');
+      c.res.headers.append('Vary', 'Origin');
+    }
+  });
 
   app.use('*', async (c, next) => {
     const traceId = crypto.randomUUID();
@@ -45,7 +85,7 @@ function createApp() {
     try {
       await next();
     } catch (error) {
-      console.error(error);
+      safeLogError(error);
       const payload = toStorageErrorPayload(error, 500);
       const envelope = {
         success: false,
@@ -200,6 +240,305 @@ function createApp() {
     return null;
   }
 
+  // Requirement #1: the admin API fails closed when auth is not configured.
+  function requireAdminAuth(c) {
+    const { authService } = getServices(c);
+    if (!authService.isAuthRequired()) {
+      return apiV1Error('ADMIN_AUTH_NOT_CONFIGURED', 'Admin authentication is not configured.', 503, {
+        detail: 'Set BASIC_USER and BASIC_PASS to enable the admin API. The admin API fails closed.',
+      });
+    }
+    const result = authResult(c);
+    if (!result.authenticated) {
+      return apiV1Error('UNAUTHORIZED', 'Authentication required.', 401, { detail: result.reason || 'Unauthorized' });
+    }
+    c.set('auth', result);
+    return null;
+  }
+
+  function tokenErrorResponse(c, error, fallbackCode, fallbackMessage) {
+    const code = error?.code || fallbackCode;
+    if (code === 'INVALID_SCOPE') {
+      return apiV1Error('INVALID_SCOPE', error.message || 'Invalid scopes.', 400, {
+        invalidScopes: Array.isArray(error.invalidScopes) ? error.invalidScopes : [],
+      });
+    }
+    if (code === 'INVALID_EXPIRY') {
+      return apiV1Error('INVALID_EXPIRY', error.message || 'Invalid expiry.', 400);
+    }
+    if (code === 'INVALID_POLICY') {
+      return apiV1Error('INVALID_POLICY', error.message || 'Invalid policies.', 400, {
+        invalidStorages: Array.isArray(error.invalidStorages) ? error.invalidStorages : undefined,
+        invalidMimeTypes: Array.isArray(error.invalidMimeTypes) ? error.invalidMimeTypes : undefined,
+        invalidHosts: Array.isArray(error.invalidHosts) ? error.invalidHosts : undefined,
+      });
+    }
+    return apiV1Error(code, error?.message || fallbackMessage, 400);
+  }
+
+  // Requirement #10: per-token policy enforcement.
+  function enforceTokenPolicy(c, { storage = '', mimeType = null, fileSize = null, folderPath = '', checkSourceHost = false } = {}) {
+    const token = c.get('apiToken');
+    const policies = token?.policies;
+    if (!policies) return null;
+
+    if (Array.isArray(policies.allowedStorages) && policies.allowedStorages.length > 0 && storage) {
+      if (!policies.allowedStorages.includes(storage)) {
+        return apiV1Error('POLICY_DENIED', `Token policy does not allow storage "${storage}".`, 403, {
+          allowedStorages: policies.allowedStorages,
+        });
+      }
+    }
+    if (Array.isArray(policies.allowedMimeTypes) && policies.allowedMimeTypes.length > 0 && mimeType) {
+      if (!policies.allowedMimeTypes.includes(String(mimeType).toLowerCase())) {
+        return apiV1Error('POLICY_DENIED', `Token policy does not allow MIME type "${mimeType}".`, 403, {
+          allowedMimeTypes: policies.allowedMimeTypes,
+        });
+      }
+    }
+    if (policies.maxFileSize != null && fileSize != null && Number(fileSize) > Number(policies.maxFileSize)) {
+      return apiV1Error('POLICY_FILE_TOO_LARGE', `File exceeds the token policy limit (${policies.maxFileSize} bytes).`, 413);
+    }
+    if (policies.folderPrefix) {
+      const prefix = String(policies.folderPrefix).replace(/\/+$/, '');
+      const folder = String(folderPath || '');
+      if (folder !== prefix && !folder.startsWith(`${prefix}/`)) {
+        return apiV1Error('POLICY_DENIED', `folderPath must start with "${prefix}".`, 403);
+      }
+    }
+    if (checkSourceHost && Array.isArray(policies.allowedSourceHosts) && policies.allowedSourceHosts.length > 0) {
+      const origin = c.req.header('Origin') || '';
+      const referer = c.req.header('Referer') || '';
+      let sourceHost = '';
+      try {
+        if (referer) sourceHost = new URL(referer).hostname.toLowerCase();
+        else if (origin) sourceHost = new URL(origin).hostname.toLowerCase();
+      } catch {
+        sourceHost = '';
+      }
+      if (!sourceHost || !policies.allowedSourceHosts.includes(sourceHost)) {
+        return apiV1Error('POLICY_DENIED', `Source host "${sourceHost || 'unknown'}" is not allowed by token policy.`, 403);
+      }
+    }
+    return null;
+  }
+
+  // Binary-safe SHA-256 (app-level sha256Hex stringifies its input).
+  function sha256HexBytes(data) {
+    return crypto.createHash('sha256').update(data).digest('hex');
+  }
+
+  // Requirement #11: Idempotency-Key replay helpers.
+  function findIdempotentResponse(db, cacheKey) {
+    try {
+      const row = dbGet(db, 'SELECT response_json, status_code FROM idempotency_keys WHERE key = ? AND expires_at > ?', [cacheKey, Date.now()]);
+      if (!row) return null;
+      try {
+        return { payload: JSON.parse(row.response_json), status: Number(row.status_code || 200) };
+      } catch {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  function saveIdempotentResponse(db, cacheKey, payload, status = 200) {
+    try {
+      const tokenId = String(cacheKey).split(':')[0];
+      dbRun(
+        db,
+        `INSERT INTO idempotency_keys(key, token_id, response_json, status_code, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(key) DO NOTHING`,
+        [cacheKey, tokenId, JSON.stringify(payload), Number(status || 200), Date.now(), Date.now() + 24 * 3600 * 1000]
+      );
+    } catch (error) {
+      safeLogError(error);
+    }
+  }
+
+  function findDeduplicatedFile(db, fileRepo, contentSha256) {
+    try {
+      const row = dbGet(db, 'SELECT file_id FROM sha_dedup_index WHERE sha256 = ? AND expires_at > ?', [contentSha256, Date.now()]);
+      if (!row) return null;
+      return fileRepo.getById(row.file_id) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  function saveShaDedupIndex(db, contentSha256, fileRecord) {
+    if (!contentSha256 || !fileRecord?.id) return;
+    try {
+      dbRun(
+        db,
+        `INSERT INTO sha_dedup_index(sha256, file_id, file_name, storage_type, file_size, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(sha256) DO NOTHING`,
+        [
+          contentSha256,
+          fileRecord.id,
+          fileRecord.file_name || '',
+          fileRecord.storage_type || '',
+          Number(fileRecord.file_size || 0),
+          Date.now(),
+          Date.now() + 90 * 24 * 3600 * 1000,
+        ]
+      );
+    } catch (error) {
+      safeLogError(error);
+    }
+  }
+
+  const IMPORT_STORAGE_LIMITS = {
+    discord: 25 * 1024 * 1024,
+    huggingface: 35 * 1024 * 1024,
+    telegram: 50 * 1024 * 1024,
+  };
+  const DEDUP_MAX_BYTES = 25 * 1024 * 1024;
+  const IMPORT_IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/bmp', 'image/x-icon']);
+
+  function buildImportFileName(rawUrl, mime) {
+    let name = '';
+    try {
+      const parsed = new URL(rawUrl);
+      name = decodeURIComponent(parsed.pathname.split('/').pop() || '');
+    } catch {
+      name = '';
+    }
+    name = String(name || '').replace(/[^\w.-]+/g, '_').replace(/^\.+/, '').slice(0, 120);
+    const extensions = {
+      'image/jpeg': '.jpg',
+      'image/png': '.png',
+      'image/webp': '.webp',
+      'image/avif': '.avif',
+      'image/gif': '.gif',
+      'image/bmp': '.bmp',
+      'image/x-icon': '.ico',
+    };
+    const expectedExt = extensions[mime] || '';
+    if (!name || !path.extname(name)) {
+      name = (name || 'imported-image') + expectedExt;
+    }
+    return name || `imported-image${expectedExt}`;
+  }
+
+  // Requirement #6: SSRF-validated remote fetch for /api/v1/import.
+  // Every redirect hop is re-validated (DNS + literal rules); the body is
+  // streamed with a hard size cap; Content-Length alone is never trusted.
+  async function fetchRemoteImport(rawUrl, maxBytes) {
+    let currentUrl = String(rawUrl || '').trim();
+
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+      const safety = await assertSafeRemoteUrl(currentUrl);
+      if (!safety.ok) {
+        const error = new Error(safety.message || 'Unsafe remote URL.');
+        error.code = safety.code || 'SSRF_BLOCKED';
+        error.status = safety.code === 'INVALID_URL' ? 400 : 403;
+        throw error;
+      }
+
+      let response;
+      try {
+        response = await fetch(currentUrl, { redirect: 'manual', signal: AbortSignal.timeout(30000) });
+      } catch (error) {
+        const wrapped = new Error(`Failed to fetch remote URL: ${error?.message || 'network error'}`);
+        wrapped.code = 'IMPORT_FETCH_FAILED';
+        wrapped.status = 502;
+        throw wrapped;
+      }
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location') || '';
+        if (!location) {
+          const e = new Error('Remote server returned a redirect without a location.');
+          e.code = 'IMPORT_REDIRECT_INVALID';
+          e.status = 502;
+          throw e;
+        }
+        const redirectCheck = validateRedirectLocation(location, currentUrl);
+        if (!redirectCheck.ok) {
+          const e = new Error(redirectCheck.message || 'Unsafe redirect target.');
+          e.code = redirectCheck.code || 'SSRF_BLOCKED';
+          e.status = redirectCheck.code === 'INVALID_REDIRECT' ? 502 : 403;
+          throw e;
+        }
+        currentUrl = redirectCheck.url.href;
+        continue;
+      }
+
+      if (!response.ok) {
+        const e = new Error(`Remote server responded ${response.status}.`);
+        e.code = 'IMPORT_REMOTE_ERROR';
+        e.status = 502;
+        throw e;
+      }
+
+      const headerMime = String(response.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+      const contentLength = Number(response.headers.get('content-length') || 0);
+      if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+        const e = new Error('Remote file exceeds the import size limit.');
+        e.code = 'FILE_TOO_LARGE';
+        e.status = 413;
+        throw e;
+      }
+
+      const reader = response.body.getReader();
+      const chunks = [];
+      let received = 0;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          received += value.byteLength;
+          if (received > maxBytes) {
+            const e = new Error('Remote file exceeds the import size limit.');
+            e.code = 'FILE_TOO_LARGE';
+            e.status = 413;
+            throw e;
+          }
+          chunks.push(Buffer.from(value));
+        }
+      } finally {
+        try { await reader.cancel(); } catch { /* already closed */ }
+      }
+
+      const bytes = Buffer.concat(chunks);
+
+      // SVG is rejected by default (XSS risk); sniff both header and bytes.
+      if (headerMime.includes('svg') || bytes.subarray(0, 512).toString('latin1').trimStart().startsWith('<svg')) {
+        const e = new Error('SVG files are not allowed for remote import.');
+        e.code = 'UNSUPPORTED_MEDIA_TYPE';
+        e.status = 415;
+        throw e;
+      }
+
+      const sniffed = sniffImageMime(bytes.subarray(0, 32));
+      if (!sniffed || !IMPORT_IMAGE_MIMES.has(sniffed)) {
+        const e = new Error('Remote content is not a supported image type.');
+        e.code = 'UNSUPPORTED_MEDIA_TYPE';
+        e.status = 415;
+        throw e;
+      }
+      if (headerMime.startsWith('image/') && headerMime !== sniffed && headerMime !== 'image/x-icon') {
+        const e = new Error(`Content-Type (${headerMime}) does not match detected content (${sniffed}).`);
+        e.code = 'MIME_MISMATCH';
+        e.status = 415;
+        throw e;
+      }
+
+      const fileName = buildImportFileName(currentUrl, sniffed);
+      const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      return { bytes, buffer: arrayBuffer, mime: sniffed, fileName, finalUrl: currentUrl };
+    }
+
+    const e = new Error(`Too many redirects (max ${MAX_REDIRECTS}).`);
+    e.code = 'IMPORT_TOO_MANY_REDIRECTS';
+    e.status = 502;
+    throw e;
+  }
+
   function apiV1Success(payload = {}, status = 200, headers = {}) {
     return new Response(
       JSON.stringify({
@@ -252,9 +591,15 @@ function createApp() {
     return Math.min(Math.max(parsed, min), max);
   }
 
+  // Requirement #8: strict expiry semantics (parity with Pages).
+  // Accepts expiresAtMs | ISO-8601 expiresAt | expires_in/expiresIn/expiresInDays seconds.
+  // Bare numeric expiresAt throws INVALID_EXPIRY (unit ambiguity).
   function normalizeExpiryInput(body = {}) {
+    if (Object.prototype.hasOwnProperty.call(body, 'expiresAtMs')) {
+      return parseExpiryInput({ expiresAtMs: body.expiresAtMs });
+    }
     if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
-      return normalizeExpiresAt(body.expiresAt);
+      return parseExpiryInput(body.expiresAt);
     }
     if (Object.prototype.hasOwnProperty.call(body, 'expires_in')) {
       const seconds = parsePositiveInt(body.expires_in, { defaultValue: 0, min: 1, max: 3650 * 24 * 3600 });
@@ -279,7 +624,10 @@ function createApp() {
     if (!pathname.startsWith(base)) return '';
     const subPath = pathname.slice(base.length) || '/';
 
+    if (method === 'GET' && subPath === '/me') return '@me';
+    if (method === 'GET' && subPath === '/capabilities') return ''; // public, no token required
     if (method === 'POST' && subPath === '/upload') return 'upload';
+    if (method === 'POST' && subPath === '/import') return 'upload';
     if (method === 'GET' && subPath === '/files') return 'read';
     if (method === 'GET' && /^\/file\/[^/]+$/.test(subPath)) return 'read';
     if (method === 'GET' && /^\/file\/[^/]+\/info$/.test(subPath)) return 'read';
@@ -298,8 +646,16 @@ function createApp() {
     const scope = requiredScope || resolveApiV1RequiredScope(c);
     if (!scope) return null;
 
-    const result = apiTokenRepo.verify(parseBearerToken(c.req.raw), scope);
+    const tokenValue = parseBearerToken(c.req.raw);
+    const result = apiTokenRepo.verify(tokenValue, scope);
     if (!result.ok) {
+      writeAuditLog(container.db, {
+        event: AUDIT_EVENTS.TOKEN_VERIFY_FAILED,
+        operation: String(scope || '').slice(0, 64),
+        success: false,
+        client: String(c.req.header('User-Agent') || '').slice(0, 80),
+        detail: result.code || 'TOKEN_INVALID',
+      });
       return apiV1Error(
         result.code || 'TOKEN_INVALID',
         result.message || 'API Token is invalid.',
@@ -307,8 +663,24 @@ function createApp() {
       );
     }
 
-    c.set('apiToken', result.token);
-    apiTokenRepo.touchLastUsed(result.token.id);
+    // Requirement #10: per-token rate limiting.
+    const rateLimit = apiTokenRepo.checkTokenRateLimit(result.token);
+    if (!rateLimit.allowed) {
+      return apiV1Error('RATE_LIMITED', 'Token rate limit exceeded.', 429, {
+        retryAfterMs: rateLimit.retryAfterMs,
+      }, { 'Retry-After': String(Math.ceil(rateLimit.retryAfterMs / 1000)) });
+    }
+
+    // Store a redacted public record on the context (no hash/salt/secret).
+    c.set('apiToken', apiTokenRepo.toPublicRecord(result.token));
+
+    const requestMethod = String(c.req.method || 'GET').toUpperCase();
+    const requestPath = new URL(c.req.url).pathname;
+    apiTokenRepo.touchApiTokenUsage(result.token.id, {
+      success: true,
+      operation: `${requestMethod} ${requestPath}`.slice(0, 64),
+      client: String(c.req.header('User-Agent') || '').slice(0, 80),
+    });
     return null;
   }
 
@@ -975,9 +1347,9 @@ function createApp() {
   app.get('/api/manage/logout', handleManageLogout);
   app.post('/api/manage/logout', handleManageLogout);
 
-  // --- Admin API Token management ---
+  // --- Admin API Token management (fail-closed, requirement #1) ---
   app.get('/api/admin/tokens', (c) => {
-    const unauthorized = requireAuth(c);
+    const unauthorized = requireAdminAuth(c);
     if (unauthorized) return unauthorized;
 
     const { apiTokenRepo } = getServices(c);
@@ -988,7 +1360,7 @@ function createApp() {
   });
 
   app.post('/api/admin/tokens', async (c) => {
-    const unauthorized = requireAuth(c);
+    const unauthorized = requireAdminAuth(c);
     if (unauthorized) return unauthorized;
 
     const { apiTokenRepo } = getServices(c);
@@ -1003,7 +1375,16 @@ function createApp() {
         name,
         scopes: body?.scopes || [],
         expiresAt: normalizeExpiryInput(body),
+        policies: body?.policies ?? null,
         enabled: body?.enabled !== false,
+      });
+
+      writeAuditLog(container.db, {
+        event: AUDIT_EVENTS.TOKEN_CREATED,
+        tokenId: created.record.id,
+        operation: 'create',
+        client: String(c.req.header('User-Agent') || '').slice(0, 80),
+        detail: `name=${created.record.name}; scopes=${created.record.scopes.join(',')}`,
       });
 
       return apiV1Success({
@@ -1011,12 +1392,12 @@ function createApp() {
         tokenInfo: created.record,
       }, 201);
     } catch (error) {
-      return apiV1Error('TOKEN_CREATE_FAILED', error.message || 'Failed to create API Token.', 400);
+      return tokenErrorResponse(c, error, 'TOKEN_CREATE_FAILED', 'Failed to create API Token.');
     }
   });
 
   app.patch('/api/admin/tokens/:id', async (c) => {
-    const unauthorized = requireAuth(c);
+    const unauthorized = requireAdminAuth(c);
     if (unauthorized) return unauthorized;
 
     const tokenId = decodePathParam(c.req.param('id'));
@@ -1035,12 +1416,17 @@ function createApp() {
     if (Object.prototype.hasOwnProperty.call(body, 'scopes')) {
       patch.scopes = body.scopes;
     }
-    if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
-      patch.expiresAt = normalizeExpiresAt(body.expiresAt);
+    if (Object.prototype.hasOwnProperty.call(body, 'expiresAtMs')) {
+      patch.expiresAt = parseExpiryInput({ expiresAtMs: body.expiresAtMs });
+    } else if (Object.prototype.hasOwnProperty.call(body, 'expiresAt')) {
+      patch.expiresAt = parseExpiryInput(body.expiresAt);
     }
     if (Object.prototype.hasOwnProperty.call(body, 'expires_in')) {
       const seconds = Number.parseInt(String(body.expires_in), 10);
       patch.expiresAt = Number.isFinite(seconds) && seconds > 0 ? Date.now() + seconds * 1000 : null;
+    }
+    if (Object.prototype.hasOwnProperty.call(body, 'policies')) {
+      patch.policies = body.policies;
     }
 
     if (Object.keys(patch).length === 0) {
@@ -1053,14 +1439,33 @@ function createApp() {
       if (!token) {
         return apiV1Error('TOKEN_NOT_FOUND', 'API Token not found.', 404);
       }
-      return apiV1Success({ token });
+
+      if (Object.prototype.hasOwnProperty.call(patch, 'enabled')) {
+        writeAuditLog(container.db, {
+          event: patch.enabled ? AUDIT_EVENTS.TOKEN_ENABLED : AUDIT_EVENTS.TOKEN_DISABLED,
+          tokenId,
+          operation: 'update',
+          client: String(c.req.header('User-Agent') || '').slice(0, 80),
+        });
+      }
+      if (Object.prototype.hasOwnProperty.call(patch, 'scopes')) {
+        writeAuditLog(container.db, {
+          event: AUDIT_EVENTS.TOKEN_SCOPE_CHANGED,
+          tokenId,
+          operation: 'update',
+          client: String(c.req.header('User-Agent') || '').slice(0, 80),
+          detail: `scopes=${token.record.scopes.join(',')}`,
+        });
+      }
+
+      return apiV1Success({ token: token.record });
     } catch (error) {
-      return apiV1Error('TOKEN_UPDATE_FAILED', error.message || 'Failed to update API Token.', 400);
+      return tokenErrorResponse(c, error, 'TOKEN_UPDATE_FAILED', 'Failed to update API Token.');
     }
   });
 
   app.delete('/api/admin/tokens/:id', (c) => {
-    const unauthorized = requireAuth(c);
+    const unauthorized = requireAdminAuth(c);
     if (unauthorized) return unauthorized;
 
     const tokenId = decodePathParam(c.req.param('id'));
@@ -1072,7 +1477,50 @@ function createApp() {
     if (!apiTokenRepo.delete(tokenId)) {
       return apiV1Error('TOKEN_NOT_FOUND', 'API Token not found.', 404);
     }
+    writeAuditLog(container.db, {
+      event: AUDIT_EVENTS.TOKEN_DELETED,
+      tokenId,
+      operation: 'delete',
+      client: String(c.req.header('User-Agent') || '').slice(0, 80),
+    });
     return apiV1Success({ deleted: true });
+  });
+
+  // Requirement #7: rotate a token. The full new secret is returned exactly
+  // once; the old secret stops working immediately (stored hash changes).
+  app.post('/api/admin/tokens/:id/rotate', async (c) => {
+    const unauthorized = requireAdminAuth(c);
+    if (unauthorized) return unauthorized;
+
+    const tokenId = decodePathParam(c.req.param('id'));
+    if (!tokenId) {
+      return apiV1Error('VALIDATION_ERROR', 'Token id is required.', 400);
+    }
+
+    const { apiTokenRepo } = getServices(c);
+    try {
+      const rotated = apiTokenRepo.rotate(tokenId);
+      if (!rotated) {
+        return apiV1Error('TOKEN_NOT_FOUND', 'API Token not found.', 404);
+      }
+      writeAuditLog(container.db, {
+        event: AUDIT_EVENTS.TOKEN_ROTATED,
+        tokenId,
+        operation: 'rotate',
+        client: String(c.req.header('User-Agent') || '').slice(0, 80),
+      });
+      return apiV1Success({ token: rotated.token, tokenInfo: rotated.record }, 200);
+    } catch (error) {
+      return tokenErrorResponse(c, error, 'TOKEN_ROTATE_FAILED', 'Failed to rotate API Token.');
+    }
+  });
+
+  // Requirement #12: audit log query endpoint (admin only).
+  app.get('/api/admin/audit-logs', (c) => {
+    const unauthorized = requireAdminAuth(c);
+    if (unauthorized) return unauthorized;
+    const limit = parsePositiveInt(c.req.query('limit'), { defaultValue: 100, min: 1, max: 500 });
+    return apiV1Success({ logs: listAuditLogs(container.db, { limit }) });
   });
 
   app.use('/api/v1/*', async (c, next) => {
@@ -1116,6 +1564,51 @@ function createApp() {
         uploadLimit.message || 'File exceeds selected storage limit.',
         413
       );
+    }
+
+    // Requirement #10: per-token policy enforcement for API uploads.
+    const uploadFolder = normalizeFolderPath(body.folderPath || body.folder || '');
+    const uploadMime = file.type || normalizeMimeType(file.name);
+    const policyError = enforceTokenPolicy(c, {
+      storage: storageMode,
+      mimeType: uploadMime,
+      fileSize,
+      folderPath: uploadFolder,
+    });
+    if (policyError) return policyError;
+
+    // Requirement #11: Idempotency-Key replay support.
+    const idempotencyKey = String(c.req.header('Idempotency-Key') || '').trim().slice(0, 200);
+    const apiTokenRecord = c.get('apiToken');
+    const idemCacheKey = apiTokenRecord && idempotencyKey
+      ? `${apiTokenRecord.id}:${sha256HexBytes(idempotencyKey)}`
+      : null;
+    if (idemCacheKey) {
+      const replay = findIdempotentResponse(container.db, idemCacheKey);
+      if (replay) {
+        return apiV1Success(replay.payload, replay.status, { 'Idempotency-Replayed': 'true' });
+      }
+    }
+
+    // Requirement #11: SHA-256 content deduplication for small uploads.
+    const contentSha256 = sha256HexBytes(Buffer.from(fileBuffer));
+    if (fileSize <= DEDUP_MAX_BYTES) {
+      const existing = findDeduplicatedFile(container.db, container.fileRepo, contentSha256);
+      if (existing) {
+        const dedupPayload = {
+          file: mapV1File(existing),
+          links: {
+            download: toAbsoluteUrl(c, `/file/${encodeURIComponent(existing.id)}`),
+            share: existing.metadata?.shareSlug
+              ? toAbsoluteUrl(c, `/s/${encodeURIComponent(existing.metadata.shareSlug)}`)
+              : null,
+            delete: toAbsoluteUrl(c, `/api/v1/file/${encodeURIComponent(existing.id)}`),
+          },
+          deduplicated: true,
+        };
+        if (idemCacheKey) saveIdempotentResponse(container.db, idemCacheKey, dedupPayload, 200);
+        return apiV1Success(dedupPayload);
+      }
     }
 
     const rawSlug = String(body.slug || url.searchParams.get('slug') || '');
@@ -1186,14 +1679,206 @@ function createApp() {
 
     const shareId = sanitizeSlug(fileRecord.metadata?.shareSlug || '') || fileRecord.id;
 
-    return apiV1Success({
+    const uploadPayload = {
       file: mapV1File(fileRecord),
       links: {
         download: toAbsoluteUrl(c, `/file/${encodeURIComponent(fileRecord.id)}`),
         share: toAbsoluteUrl(c, `/s/${encodeURIComponent(shareId)}`),
         delete: toAbsoluteUrl(c, `/api/v1/file/${encodeURIComponent(fileRecord.id)}`),
       },
+    };
+    if (idemCacheKey) saveIdempotentResponse(container.db, idemCacheKey, uploadPayload, 200);
+    saveShaDedupIndex(container.db, contentSha256, fileRecord);
+
+    return apiV1Success(uploadPayload);
+  });
+
+  // Requirement #4: token introspection endpoint.
+  app.get('/api/v1/me', (c) => {
+    const token = c.get('apiToken');
+    if (!token) {
+      return apiV1Error('TOKEN_INVALID', 'API Token is invalid.', 401);
+    }
+    const { apiTokenRepo } = getServices(c);
+    const record = apiTokenRepo.getById(token.id);
+    const safe = apiTokenRepo.toPublicRecord(record || token, apiTokenRepo.getStat(token.id));
+    return apiV1Success({
+      data: {
+        token: {
+          id: safe.id,
+          name: safe.name,
+          scopes: safe.scopes,
+          expiresAt: safe.expiresAt,
+          enabled: safe.enabled,
+          policies: safe.policies,
+          createdAt: safe.createdAt,
+          lastUsedAt: safe.lastUsedAt,
+          usageCount: safe.usageCount,
+        },
+      },
     });
+  });
+
+  // Requirement #5: capabilities endpoint (public, no token required).
+  app.get('/api/v1/capabilities', (c) => {
+    const readiness = getBootstrapReadiness(container.config);
+    const configuredStorages = Object.entries(readiness.byType)
+      .filter(([, available]) => available)
+      .map(([type]) => type);
+    return apiV1Success({
+      data: {
+        apiVersion: 'v1',
+        upload: true,
+        importFromUrl: true,
+        maxUploadSize: container.config.uploadMaxSize,
+        storages: configuredStorages,
+        imageTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/bmp'],
+      },
+    });
+  });
+
+  // Requirement #6: agent-oriented remote URL import with strict SSRF protection.
+  app.post('/api/v1/import', async (c) => {
+    const { uploadService, fileRepo } = getServices(c);
+    const token = c.get('apiToken');
+
+    let body;
+    try {
+      body = await c.req.json();
+    } catch {
+      return apiV1Error('BAD_REQUEST', 'Request body must be JSON.', 400);
+    }
+
+    const rawUrl = String(body?.url || '').trim();
+    if (!rawUrl) {
+      return apiV1Error('VALIDATION_ERROR', 'Field "url" is required.', 400);
+    }
+
+    const storage = String(body?.storage || '').trim().toLowerCase();
+    if (storage && !VALID_STORAGES.includes(storage)) {
+      return apiV1Error('INVALID_STORAGE', `Unknown storage backend "${storage}".`, 400, {
+        allowedStorages: VALID_STORAGES,
+      });
+    }
+    const folder = normalizeFolderPath(body?.folder || '');
+
+    const policyError = enforceTokenPolicy(c, {
+      storage,
+      folderPath: folder,
+      checkSourceHost: true,
+    });
+    if (policyError) return policyError;
+
+    const idempotencyKey = String(c.req.header('Idempotency-Key') || '').trim().slice(0, 200);
+    const idemCacheKey = token && idempotencyKey
+      ? `${token.id}:${sha256HexBytes(idempotencyKey)}`
+      : null;
+    if (idemCacheKey) {
+      const replay = findIdempotentResponse(container.db, idemCacheKey);
+      if (replay) {
+        return apiV1Success(replay.payload, replay.status, { 'Idempotency-Replayed': 'true' });
+      }
+    }
+
+    let fetched;
+    try {
+      fetched = await fetchRemoteImport(rawUrl, container.config.uploadMaxSize);
+    } catch (error) {
+      return apiV1Error(
+        error?.code || 'IMPORT_FAILED',
+        error?.message || 'Remote import failed.',
+        error?.status || 502
+      );
+    }
+
+    const policyMimeError = enforceTokenPolicy(c, {
+      storage,
+      mimeType: fetched.mime,
+      fileSize: fetched.bytes.length,
+      folderPath: folder,
+    });
+    if (policyMimeError) return policyMimeError;
+
+    const storageKey = storage || container.config.bootstrapDefaultStorage?.type || 'telegram';
+    const storageLimit = IMPORT_STORAGE_LIMITS[storageKey];
+    if (storageLimit && fetched.bytes.length > storageLimit) {
+      return apiV1Error('FILE_TOO_LARGE', `File exceeds the ${storageKey} storage limit.`, 413);
+    }
+
+    const contentSha256 = sha256HexBytes(fetched.bytes);
+
+    if (body?.deduplicate !== false) {
+      const existing = findDeduplicatedFile(container.db, fileRepo, contentSha256);
+      if (existing) {
+        const dedupPayload = {
+          data: {
+            file: {
+              id: existing.id,
+              name: existing.file_name,
+              size: Number(existing.file_size || 0),
+              mime: existing.mime_type || fetched.mime,
+              sha256: contentSha256,
+              storage: existing.storage_type,
+            },
+            links: {
+              download: toAbsoluteUrl(c, `/file/${encodeURIComponent(existing.id)}`),
+              share: existing.metadata?.shareSlug
+                ? toAbsoluteUrl(c, `/s/${encodeURIComponent(existing.metadata.shareSlug)}`)
+                : null,
+            },
+            source: { url: rawUrl },
+            deduplicated: true,
+          },
+        };
+        if (idemCacheKey) saveIdempotentResponse(container.db, idemCacheKey, dedupPayload, 200);
+        return apiV1Success(dedupPayload);
+      }
+    }
+
+    let result;
+    try {
+      result = await uploadService.uploadFile({
+        fileName: fetched.fileName,
+        mimeType: fetched.mime,
+        fileSize: fetched.bytes.length,
+        buffer: fetched.buffer,
+        storageMode: storage,
+        folderPath: folder,
+      });
+    } catch (error) {
+      const payload = toStorageErrorPayload(error, error?.status || 502);
+      return apiV1Error(
+        payload.code === 'FILE_TOO_LARGE' ? 'FILE_TOO_LARGE' : 'IMPORT_UPLOAD_FAILED',
+        payload.message || error?.message || 'Import upload failed.',
+        payload.code === 'FILE_TOO_LARGE' ? 413 : 502
+      );
+    }
+
+    const fileRecord = result.file;
+    const importPayload = {
+      data: {
+        file: {
+          id: fileRecord.id,
+          name: fileRecord.file_name,
+          size: Number(fileRecord.file_size || fetched.bytes.length),
+          mime: fileRecord.mime_type || fetched.mime,
+          sha256: contentSha256,
+          storage: fileRecord.storage_type,
+        },
+        links: {
+          download: toAbsoluteUrl(c, `/file/${encodeURIComponent(fileRecord.id)}`),
+          share: fileRecord.metadata?.shareSlug
+            ? toAbsoluteUrl(c, `/s/${encodeURIComponent(fileRecord.metadata.shareSlug)}`)
+            : null,
+        },
+        source: { url: rawUrl },
+        deduplicated: false,
+      },
+    };
+    if (idemCacheKey) saveIdempotentResponse(container.db, idemCacheKey, importPayload, 200);
+    saveShaDedupIndex(container.db, contentSha256, fileRecord);
+
+    return apiV1Success(importPayload);
   });
 
   app.get('/api/v1/files', (c) => {

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,4 +1,4 @@
-﻿const fs = require('node:fs');
+const fs = require('node:fs');
 const path = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 
@@ -12,6 +12,13 @@ function executeStatement(stmt, method, params) {
   return stmt[method](params);
 }
 
+function ensureColumn(db, table, column, ddl) {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (!columns.some((col) => col.name === column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`);
+  }
+}
+
 function initDatabase(dbPath) {
   const fullPath = path.resolve(dbPath);
   fs.mkdirSync(path.dirname(fullPath), { recursive: true });
@@ -20,6 +27,12 @@ function initDatabase(dbPath) {
   const schemaPath = path.resolve(__dirname, 'schema.sql');
   const schema = fs.readFileSync(schemaPath, 'utf8');
   db.exec(schema);
+
+  // Migrations for databases created before the token-platform refactor:
+  // CREATE TABLE IF NOT EXISTS cannot add columns to an existing table.
+  ensureColumn(db, 'api_tokens', 'policies_json', 'TEXT');
+  ensureColumn(db, 'api_tokens', 'rotated_at', 'INTEGER');
+  ensureColumn(db, 'idempotency_keys', 'status_code', 'INTEGER NOT NULL DEFAULT 200');
 
   return db;
 }
@@ -55,10 +68,17 @@ function cleanupExpiredState(db) {
   const now = Date.now();
   run(db, 'DELETE FROM sessions WHERE expires_at <= ?', [now]);
   run(db, 'DELETE FROM chunk_uploads WHERE expires_at <= ?', [now]);
+  try {
+    run(db, 'DELETE FROM idempotency_keys WHERE expires_at <= ?', [now]);
+    run(db, 'DELETE FROM sha_dedup_index WHERE expires_at <= ?', [now]);
+  } catch {
+    // Tables are created by schema.sql; tolerate databases mid-migration.
+  }
 }
 
 module.exports = {
   initDatabase,
+  ensureColumn,
   run,
   get,
   all,

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -91,7 +91,9 @@ CREATE TABLE IF NOT EXISTS api_tokens (
   token_salt TEXT NOT NULL,
   token_hash TEXT NOT NULL,
   token_suffix TEXT NOT NULL,
-  token_preview TEXT NOT NULL
+  token_preview TEXT NOT NULL,
+  policies_json TEXT,
+  rotated_at INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_api_tokens_created_at ON api_tokens(created_at DESC);
@@ -118,3 +120,55 @@ CREATE TABLE IF NOT EXISTS app_settings (
 );
 
 CREATE INDEX IF NOT EXISTS idx_app_settings_updated_at ON app_settings(updated_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- API Token platform (per-token policies, telemetry, audit, idempotency, dedup)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS token_stats (
+  token_id TEXT PRIMARY KEY,
+  last_used_at INTEGER,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_success_at INTEGER,
+  last_failure_at INTEGER,
+  last_operation TEXT,
+  last_client TEXT,
+  last_touch_at INTEGER,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event TEXT NOT NULL,
+  token_id TEXT,
+  operation TEXT,
+  timestamp INTEGER NOT NULL,
+  success INTEGER NOT NULL DEFAULT 1,
+  client TEXT,
+  detail TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp ON audit_logs(timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  key TEXT PRIMARY KEY,
+  token_id TEXT NOT NULL,
+  response_json TEXT NOT NULL,
+  status_code INTEGER NOT NULL DEFAULT 200,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at ON idempotency_keys(expires_at);
+
+CREATE TABLE IF NOT EXISTS sha_dedup_index (
+  sha256 TEXT PRIMARY KEY,
+  file_id TEXT NOT NULL,
+  file_name TEXT,
+  storage_type TEXT,
+  file_size INTEGER,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sha_dedup_index_expires_at ON sha_dedup_index(expires_at);

--- a/server/lib/repos/api-token-repo.js
+++ b/server/lib/repos/api-token-repo.js
@@ -3,10 +3,22 @@ const { all, get, run } = require('../../db');
 
 const TOKEN_PREFIX = 'kvault_';
 const VALID_SCOPES = new Set(['upload', 'read', 'delete', 'paste']);
+const VALID_STORAGES = ['telegram', 'r2', 's3', 'discord', 'huggingface', 'webdav', 'github'];
 const TOKEN_ID_LENGTH = 12;
 const TOKEN_SECRET_LENGTH = 40;
 const TOKEN_SALT_LENGTH = 16;
 const MASK_PREFIX = '******';
+const STAT_DEBOUNCE_MS = 60 * 1000;
+
+const MIME_PATTERN = /^[\w.+-]+\/[\w.+-]+$/;
+const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\.?$/;
+
+function tokenError(code, message, extra = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
 
 function timingSafeEqualHex(left, right) {
   const a = Buffer.from(String(left || ''), 'utf8');
@@ -43,48 +55,182 @@ function splitToken(rawToken = '') {
   const value = String(rawToken || '').trim();
   const match = /^kvault_([A-Za-z0-9_-]{6,128})_([A-Za-z0-9_-]{16,256})$/.exec(value);
   if (!match) return null;
-  return {
-    tokenId: match[1],
-    secret: match[2],
-    value,
-  };
+  return { tokenId: match[1], secret: match[2], value };
 }
 
-function normalizeExpiresAt(rawValue) {
+/** Internal: epoch-ms sanity check (internal code always passes epoch ms). */
+function normalizeExpiryMs(rawValue) {
   if (rawValue == null || rawValue === '') return null;
+  const numeric = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  return Math.floor(numeric);
+}
+
+/**
+ * Public API input parsing (requirement #8, parity with Pages).
+ * Accepts: ISO-8601 string | { expiresAtMs } explicit | null.
+ * Rejects bare numbers (seconds-vs-ms ambiguity) and unparseable strings.
+ */
+function parseExpiryInput(rawValue) {
+  if (rawValue == null || rawValue === '') return null;
+
   if (typeof rawValue === 'number') {
-    return Number.isFinite(rawValue) ? Math.max(0, Math.floor(rawValue)) : null;
+    throw tokenError('INVALID_EXPIRY', 'expiresAt must be an ISO-8601 string. Use expiresAtMs for epoch milliseconds.');
   }
+
+  if (typeof rawValue === 'object') {
+    if (Object.prototype.hasOwnProperty.call(rawValue, 'expiresAtMs')) {
+      const ms = normalizeExpiryMs(rawValue.expiresAtMs);
+      if (ms == null) {
+        throw tokenError('INVALID_EXPIRY', 'expiresAtMs must be a positive epoch-milliseconds number.');
+      }
+      return ms;
+    }
+    throw tokenError('INVALID_EXPIRY', 'Unsupported expiresAt payload.');
+  }
+
   const text = String(rawValue).trim();
   if (!text) return null;
-  const numeric = Number(text);
-  if (Number.isFinite(numeric)) {
-    return Math.max(0, Math.floor(numeric));
+
+  // Pure numeric strings are ambiguous (seconds vs ms) -> reject.
+  if (/^-?\d+$/.test(text)) {
+    throw tokenError('INVALID_EXPIRY', 'Bare numeric expiresAt is ambiguous. Send an ISO-8601 string or expiresAtMs.');
   }
+
   const parsed = Date.parse(text);
-  if (Number.isFinite(parsed)) {
-    return Math.max(0, Math.floor(parsed));
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw tokenError('INVALID_EXPIRY', `expiresAt "${text}" is not a valid ISO-8601 timestamp.`);
   }
-  return null;
+  return parsed;
 }
 
-function normalizeScopes(rawScopes = []) {
+/** Strict scope parsing (requirement #9): never silently filter. */
+function parseScopesStrict(rawScopes = []) {
   const list = Array.isArray(rawScopes) ? rawScopes : [rawScopes];
   const normalized = [];
+  const invalidScopes = [];
   list.forEach((item) => {
     const scope = String(item || '').trim().toLowerCase();
-    if (!VALID_SCOPES.has(scope)) return;
-    if (normalized.includes(scope)) return;
-    normalized.push(scope);
+    if (!scope) return;
+    if (!VALID_SCOPES.has(scope)) {
+      if (!invalidScopes.includes(scope)) invalidScopes.push(scope);
+      return;
+    }
+    if (!normalized.includes(scope)) normalized.push(scope);
   });
+  if (invalidScopes.length > 0) {
+    throw tokenError('INVALID_SCOPE', `Unknown scopes: ${invalidScopes.join(', ')}.`, { invalidScopes });
+  }
+  if (normalized.length === 0) {
+    throw tokenError('INVALID_SCOPE', 'At least one valid scope is required.', { invalidScopes: [] });
+  }
   return normalized;
 }
 
-function parseScopes(scopesJson) {
+/** Legacy read filter: old rows may contain garbage scopes; never throw on read. */
+function parseScopesJson(scopesJson) {
   try {
-    return normalizeScopes(JSON.parse(scopesJson || '[]'));
+    const list = Array.isArray(JSON.parse(scopesJson || '[]')) ? JSON.parse(scopesJson || '[]') : [];
+    return list.map((scope) => String(scope).trim().toLowerCase()).filter((scope) => VALID_SCOPES.has(scope));
   } catch {
     return [];
+  }
+}
+
+/** Per-token policies (requirement #10). Returns null when absent. */
+function normalizePolicies(raw) {
+  if (raw == null || raw === '') return null;
+  if (typeof raw === 'string') {
+    try {
+      return normalizePolicies(JSON.parse(raw));
+    } catch {
+      throw tokenError('INVALID_POLICY', 'policies must be a valid JSON object.');
+    }
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw tokenError('INVALID_POLICY', 'policies must be an object.');
+  }
+
+  const out = {};
+
+  if (raw.allowedStorages != null) {
+    const list = (Array.isArray(raw.allowedStorages) ? raw.allowedStorages : [raw.allowedStorages])
+      .map((item) => String(item || '').trim().toLowerCase())
+      .filter(Boolean);
+    const invalid = list.filter((item) => !VALID_STORAGES.includes(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Unknown storage backend(s): ${invalid.join(', ')}.`, { invalidStorages: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedStorages = unique;
+  }
+
+  if (raw.allowedMimeTypes != null) {
+    const list = (Array.isArray(raw.allowedMimeTypes) ? raw.allowedMimeTypes : [raw.allowedMimeTypes])
+      .map((item) => String(item || '').trim().toLowerCase())
+      .filter(Boolean);
+    const invalid = list.filter((item) => !MIME_PATTERN.test(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Invalid MIME type(s): ${invalid.join(', ')}.`, { invalidMimeTypes: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedMimeTypes = unique;
+  }
+
+  if (raw.maxFileSize != null) {
+    const size = Number(raw.maxFileSize);
+    if (!Number.isFinite(size) || size <= 0 || size > 1024 * 1024 * 1024) {
+      throw tokenError('INVALID_POLICY', 'maxFileSize must be a positive number of bytes (max 1GiB).');
+    }
+    out.maxFileSize = Math.floor(size);
+  }
+
+  if (raw.folderPrefix != null) {
+    const prefix = String(raw.folderPrefix).replace(/\\/g, '/').trim().replace(/^\/+/, '');
+    if (prefix.includes('..')) {
+      throw tokenError('INVALID_POLICY', 'folderPrefix must not contain path traversal.');
+    }
+    if (prefix) out.folderPrefix = prefix.replace(/\/+$/, '');
+  }
+
+  if (raw.rateLimit != null) {
+    if (typeof raw.rateLimit !== 'object' || Array.isArray(raw.rateLimit)) {
+      throw tokenError('INVALID_POLICY', 'rateLimit must be an object { windowMs, max }.');
+    }
+    const windowMs = Number(raw.rateLimit.windowMs);
+    const max = Number(raw.rateLimit.max);
+    if (!Number.isFinite(windowMs) || windowMs < 1000 || windowMs > 24 * 3600 * 1000) {
+      throw tokenError('INVALID_POLICY', 'rateLimit.windowMs must be between 1000 and 86400000 ms.');
+    }
+    if (!Number.isFinite(max) || max < 1 || max > 100000) {
+      throw tokenError('INVALID_POLICY', 'rateLimit.max must be between 1 and 100000.');
+    }
+    out.rateLimit = { windowMs: Math.floor(windowMs), max: Math.floor(max) };
+  }
+
+  if (raw.allowedSourceHosts != null) {
+    const list = (Array.isArray(raw.allowedSourceHosts) ? raw.allowedSourceHosts : [raw.allowedSourceHosts])
+      .map((item) => String(item || '').trim().toLowerCase().replace(/\.$/, ''))
+      .filter(Boolean);
+    const invalid = list.filter((item) => !HOST_PATTERN.test(item));
+    if (invalid.length > 0) {
+      throw tokenError('INVALID_POLICY', `Invalid source host(s): ${invalid.join(', ')}.`, { invalidHosts: invalid });
+    }
+    const unique = [...new Set(list)];
+    if (unique.length > 0) out.allowedSourceHosts = unique;
+  }
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function parseStoredPolicies(raw) {
+  if (raw == null || raw === '') return null;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return { ...parsed };
+  } catch {
+    return null;
   }
 }
 
@@ -104,20 +250,62 @@ function getApiTokenScopes() {
   return [...VALID_SCOPES];
 }
 
+/**
+ * API Token repository (Docker/SQLite).
+ *
+ * Requirement #2 — decoupled credential vs telemetry:
+ * - `api_tokens`   : credential only. Telemetry writes NEVER touch this table,
+ *                    so an admin disable/scope-change can never be resurrected
+ *                    by a stale read-modify-write. (Legacy last_used_at column
+ *                    remains for old rows but is no longer written.)
+ * - `token_stats`  : telemetry only, sampled with a 60s debounce.
+ * - `verify()` is a pure read: it can never resurrect a disabled token.
+ */
 class ApiTokenRepository {
   constructor(db) {
     this.db = db;
+    this._rateBuckets = new Map(); // `${tokenId}:${windowStart}` -> count
   }
 
-  toPublicRecord(record = {}) {
+  getStat(tokenId) {
+    try {
+      const row = get(
+        this.db,
+        `SELECT token_id, last_used_at, usage_count, last_success_at, last_failure_at,
+                last_operation, last_client, last_touch_at
+         FROM token_stats WHERE token_id = ?`,
+        [tokenId],
+      );
+      if (!row) return null;
+      return {
+        lastUsedAt: row.last_used_at == null ? null : Number(row.last_used_at),
+        usageCount: Number(row.usage_count || 0),
+        lastSuccessAt: row.last_success_at == null ? null : Number(row.last_success_at),
+        lastFailureAt: row.last_failure_at == null ? null : Number(row.last_failure_at),
+        lastOperation: row.last_operation || null,
+        lastClient: row.last_client || null,
+        lastTouchAt: row.last_touch_at == null ? null : Number(row.last_touch_at),
+      };
+    } catch {
+      return null; // table may not exist on databases mid-migration
+    }
+  }
+
+  toPublicRecord(record = {}, stat = null) {
+    const legacyLastUsed = record.lastUsedAt == null ? null : Number(record.lastUsedAt || 0);
     return {
       id: record.id,
       name: record.name,
       scopes: Array.isArray(record.scopes) ? [...record.scopes] : [],
       expiresAt: record.expiresAt ?? null,
       createdAt: Number(record.createdAt || 0),
-      lastUsedAt: record.lastUsedAt ?? null,
+      lastUsedAt: stat?.lastUsedAt != null ? Number(stat.lastUsedAt) : legacyLastUsed,
+      usageCount: stat?.usageCount != null ? Number(stat.usageCount) : 0,
+      lastOperation: stat?.lastOperation ?? null,
+      lastClient: stat?.lastClient ?? null,
       enabled: Boolean(record.enabled),
+      policies: record.policies ? { ...record.policies } : null,
+      rotatedAt: record.rotatedAt == null ? null : Number(record.rotatedAt || 0),
       tokenPreview: record.tokenPreview || maskTokenSuffix(record.tokenSuffix || ''),
     };
   }
@@ -127,11 +315,13 @@ class ApiTokenRepository {
     return {
       id: row.id,
       name: row.name,
-      scopes: parseScopes(row.scopes_json),
+      scopes: parseScopesJson(row.scopes_json),
       expiresAt: row.expires_at == null ? null : Number(row.expires_at || 0),
       createdAt: Number(row.created_at || 0),
       lastUsedAt: row.last_used_at == null ? null : Number(row.last_used_at || 0),
       enabled: row.enabled !== 0,
+      policies: parseStoredPolicies(row.policies_json),
+      rotatedAt: row.rotated_at == null ? null : Number(row.rotated_at || 0),
       tokenSalt: row.token_salt,
       tokenHash: row.token_hash,
       tokenSuffix: row.token_suffix,
@@ -154,16 +344,16 @@ class ApiTokenRepository {
     throw new Error('Failed to generate a unique token id.');
   }
 
-  create({ name, scopes, expiresAt, enabled = true }) {
+  create({ name, scopes, expiresAt, policies, enabled = true }) {
     const normalizedName = String(name || '').trim();
     if (!normalizedName) {
-      throw new Error('Token name is required.');
+      throw tokenError('VALIDATION_ERROR', 'Token name is required.');
     }
 
-    const normalizedScopes = normalizeScopes(scopes);
-    if (normalizedScopes.length === 0) {
-      throw new Error('At least one valid scope is required.');
-    }
+    const normalizedScopes = parseScopesStrict(scopes);
+    // Route layer parses user input via parseExpiryInput; this is epoch-ms or null.
+    const expiryMs = normalizeExpiryMs(expiresAt);
+    const normalizedPolicies = normalizePolicies(policies);
 
     const tokenId = this.generateUniqueTokenId();
     const tokenSecret = randomString(TOKEN_SECRET_LENGTH);
@@ -177,13 +367,14 @@ class ApiTokenRepository {
       this.db,
       `INSERT INTO api_tokens(
         id, name, scopes_json, expires_at, created_at, last_used_at,
-        enabled, token_salt, token_hash, token_suffix, token_preview
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        enabled, token_salt, token_hash, token_suffix, token_preview,
+        policies_json, rotated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         tokenId,
         normalizedName,
         JSON.stringify(normalizedScopes),
-        normalizeExpiresAt(expiresAt),
+        expiryMs,
         now,
         null,
         enabled !== false ? 1 : 0,
@@ -191,6 +382,8 @@ class ApiTokenRepository {
         tokenHash,
         tokenSuffix,
         tokenPreview,
+        normalizedPolicies ? JSON.stringify(normalizedPolicies) : null,
+        null,
       ]
     );
 
@@ -203,7 +396,10 @@ class ApiTokenRepository {
 
   list() {
     return all(this.db, 'SELECT * FROM api_tokens ORDER BY created_at DESC')
-      .map((row) => this.toPublicRecord(this.rowToRecord(row)));
+      .map((row) => {
+        const record = this.rowToRecord(row);
+        return this.toPublicRecord(record, this.getStat(record.id));
+      });
   }
 
   update(tokenId, patch = {}) {
@@ -211,109 +407,173 @@ class ApiTokenRepository {
     if (!current) return null;
 
     const next = { ...current };
+    const auditExtras = {};
+
     if (Object.prototype.hasOwnProperty.call(patch, 'enabled')) {
       next.enabled = Boolean(patch.enabled);
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'name')) {
       const normalizedName = String(patch.name || '').trim();
       if (!normalizedName) {
-        throw new Error('Token name is required.');
+        throw tokenError('VALIDATION_ERROR', 'Token name is required.');
       }
       next.name = normalizedName;
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'scopes')) {
-      const normalizedScopes = normalizeScopes(patch.scopes);
-      if (normalizedScopes.length === 0) {
-        throw new Error('At least one valid scope is required.');
-      }
-      next.scopes = normalizedScopes;
+      next.scopes = parseScopesStrict(patch.scopes);
+      auditExtras.scopes = [...next.scopes];
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'expiresAt')) {
-      next.expiresAt = normalizeExpiresAt(patch.expiresAt);
+      // Route layer passes epoch-ms (already parsed); accept legacy ISO strings.
+      next.expiresAt = normalizeExpiryMs(patch.expiresAt);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'policies')) {
+      next.policies = normalizePolicies(patch.policies);
     }
 
     run(
       this.db,
       `UPDATE api_tokens
-       SET name = ?, scopes_json = ?, expires_at = ?, enabled = ?
+       SET name = ?, scopes_json = ?, expires_at = ?, enabled = ?, policies_json = ?
        WHERE id = ?`,
       [
         next.name,
         JSON.stringify(next.scopes),
         next.expiresAt,
         next.enabled ? 1 : 0,
+        next.policies ? JSON.stringify(next.policies) : null,
         current.id,
       ]
     );
 
-    return this.toPublicRecord(this.getById(current.id));
+    return {
+      record: this.toPublicRecord(this.getById(current.id), this.getStat(current.id)),
+      auditExtras,
+    };
   }
 
   delete(tokenId) {
     const id = sanitizeTokenId(tokenId);
     if (!id) return false;
     const result = run(this.db, 'DELETE FROM api_tokens WHERE id = ?', [id]);
+    try {
+      run(this.db, 'DELETE FROM token_stats WHERE token_id = ?', [id]);
+    } catch {
+      // tolerate databases mid-migration
+    }
+    this._rateBuckets.clear();
     return Number(result.changes || 0) > 0;
   }
 
-  touchLastUsed(tokenId) {
-    const id = sanitizeTokenId(tokenId);
-    if (!id) return false;
-    const result = run(this.db, 'UPDATE api_tokens SET last_used_at = ? WHERE id = ?', [Date.now(), id]);
-    return Number(result.changes || 0) > 0;
+  /**
+   * Rotate a token (requirement #7): new secret, same identity/scopes/policies.
+   * The old secret stops working immediately because the stored hash changes.
+   */
+  rotate(tokenId) {
+    const record = this.getById(tokenId);
+    if (!record) return null;
+
+    const tokenSecret = randomString(TOKEN_SECRET_LENGTH);
+    const tokenSalt = randomString(TOKEN_SALT_LENGTH);
+    const tokenHash = hashTokenSecret(tokenSecret, tokenSalt);
+    const tokenSuffix = tokenSecret.slice(-6);
+    const rotatedAt = Date.now();
+
+    run(
+      this.db,
+      `UPDATE api_tokens
+       SET token_salt = ?, token_hash = ?, token_suffix = ?, token_preview = ?, rotated_at = ?
+       WHERE id = ?`,
+      [tokenSalt, tokenHash, tokenSuffix, maskTokenSuffix(tokenSuffix), rotatedAt, record.id]
+    );
+
+    return {
+      token: `${TOKEN_PREFIX}${record.id}_${tokenSecret}`,
+      record: this.toPublicRecord(this.getById(record.id), this.getStat(record.id)),
+    };
   }
 
+  /**
+   * Telemetry write (requirement #2). Writes ONLY token_stats with a 60s
+   * sample debounce. Never touches api_tokens (credentials).
+   */
+  touchApiTokenUsage(tokenId, { success = true, operation = '', client = '' } = {}) {
+    try {
+      const id = sanitizeTokenId(tokenId);
+      if (!id) return false;
+
+      const now = Date.now();
+      const stat = this.getStat(id) || {};
+
+      if (Number(stat.lastTouchAt || 0) > 0 && now - Number(stat.lastTouchAt || 0) < STAT_DEBOUNCE_MS) {
+        return false; // sampled: skip write inside the debounce window
+      }
+
+      run(
+        this.db,
+        `INSERT INTO token_stats(
+          token_id, last_used_at, usage_count, last_success_at, last_failure_at,
+          last_operation, last_client, last_touch_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(token_id) DO UPDATE SET
+          last_used_at = excluded.last_used_at,
+          usage_count = excluded.usage_count,
+          last_success_at = excluded.last_success_at,
+          last_failure_at = excluded.last_failure_at,
+          last_operation = excluded.last_operation,
+          last_client = excluded.last_client,
+          last_touch_at = excluded.last_touch_at,
+          updated_at = excluded.updated_at`,
+        [
+          id,
+          now,
+          Number(stat.usageCount || 0) + 1,
+          success ? now : (Number(stat.lastSuccessAt || 0) || null),
+          success ? (Number(stat.lastFailureAt || 0) || null) : now,
+          String(operation || stat.lastOperation || '').slice(0, 64) || null,
+          String(client || stat.lastClient || '').slice(0, 80) || null,
+          now,
+          now,
+        ]
+      );
+      return true;
+    } catch (error) {
+      console.warn('Failed to update API token usage stats:', error?.message || error);
+      return false;
+    }
+  }
+
+  /**
+   * Verify a bearer token. Pure read: never writes, so it can never resurrect
+   * a disabled token or stale scopes (requirement #2).
+   * requiredScope === '@me' means "any valid token" (introspection endpoint).
+   */
   verify(tokenValue, requiredScope = '') {
     const split = splitToken(tokenValue);
     if (!split) {
-      return {
-        ok: false,
-        status: 401,
-        code: 'TOKEN_INVALID',
-        message: 'API Token is invalid.',
-      };
+      return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
     }
 
     const record = this.getById(split.tokenId);
     if (!record) {
-      return {
-        ok: false,
-        status: 401,
-        code: 'TOKEN_INVALID',
-        message: 'API Token is invalid.',
-      };
+      return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
     }
 
     const expectedHash = hashTokenSecret(split.secret, record.tokenSalt || '');
     if (!timingSafeEqualHex(expectedHash, String(record.tokenHash || ''))) {
-      return {
-        ok: false,
-        status: 401,
-        code: 'TOKEN_INVALID',
-        message: 'API Token is invalid.',
-      };
+      return { ok: false, status: 401, code: 'TOKEN_INVALID', message: 'API Token is invalid.' };
     }
 
     if (!record.enabled) {
-      return {
-        ok: false,
-        status: 401,
-        code: 'TOKEN_DISABLED',
-        message: 'API Token is disabled.',
-      };
+      return { ok: false, status: 401, code: 'TOKEN_DISABLED', message: 'API Token is disabled.' };
     }
 
     if (Number.isFinite(record.expiresAt) && record.expiresAt > 0 && Date.now() > record.expiresAt) {
-      return {
-        ok: false,
-        status: 401,
-        code: 'TOKEN_EXPIRED',
-        message: 'API Token has expired.',
-      };
+      return { ok: false, status: 401, code: 'TOKEN_EXPIRED', message: 'API Token has expired.' };
     }
 
     const normalizedScope = String(requiredScope || '').trim().toLowerCase();
-    if (normalizedScope && !record.scopes.includes(normalizedScope)) {
+    if (normalizedScope && normalizedScope !== '@me' && !record.scopes.includes(normalizedScope)) {
       return {
         ok: false,
         status: 403,
@@ -322,16 +582,46 @@ class ApiTokenRepository {
       };
     }
 
-    return {
-      ok: true,
-      token: this.toPublicRecord(record),
-    };
+    return { ok: true, token: record };
+  }
+
+  /**
+   * Approximate per-token rate limit (requirement #10). In-memory fixed-window
+   * counters (single-process server). Returns { allowed } / { retryAfterMs }.
+   */
+  checkTokenRateLimit(record) {
+    const policy = record?.policies?.rateLimit;
+    if (!policy) return { allowed: true };
+
+    const now = Date.now();
+    const windowStart = Math.floor(now / policy.windowMs) * policy.windowMs;
+    const retryAfterMs = Math.max(windowStart + policy.windowMs - now, 1);
+
+    // Opportunistic pruning of stale windows.
+    if (this._rateBuckets.size > 10000) {
+      for (const key of this._rateBuckets.keys()) {
+        const marker = Number(key.slice(key.lastIndexOf(':') + 1));
+        if (marker < windowStart) this._rateBuckets.delete(key);
+      }
+    }
+
+    const key = `${record.id}:${windowStart}`;
+    const count = Number(this._rateBuckets.get(key) || 0);
+    if (count >= policy.max) {
+      return { allowed: false, retryAfterMs };
+    }
+    this._rateBuckets.set(key, count + 1);
+    return { allowed: true };
   }
 }
 
 module.exports = {
   ApiTokenRepository,
   getApiTokenScopes,
-  normalizeExpiresAt,
   parseBearerToken,
+  parseExpiryInput,
+  parseScopesStrict,
+  normalizePolicies,
+  normalizeExpiryMs,
+  VALID_STORAGES,
 };

--- a/server/lib/utils/audit.js
+++ b/server/lib/utils/audit.js
@@ -1,0 +1,71 @@
+/**
+ * Audit log for token management events (requirement #12) — Docker/SQLite variant.
+ *
+ * Events: TOKEN_CREATED, TOKEN_ROTATED, TOKEN_DISABLED, TOKEN_ENABLED,
+ *         TOKEN_SCOPE_CHANGED, TOKEN_DELETED, TOKEN_VERIFY_FAILED
+ *
+ * - Never records full token secrets (redaction applied to detail).
+ * - No IP addresses are stored; only a short client tag is kept.
+ * - Records live in the `audit_logs` SQLite table (180 days, pruned lazily).
+ * - Audit failures must never break the main request flow.
+ */
+
+const { redactSecrets } = require('./redact');
+
+const AUDIT_TTL_MS = 180 * 24 * 3600 * 1000;
+
+const AUDIT_EVENTS = {
+  TOKEN_CREATED: 'TOKEN_CREATED',
+  TOKEN_ROTATED: 'TOKEN_ROTATED',
+  TOKEN_DISABLED: 'TOKEN_DISABLED',
+  TOKEN_ENABLED: 'TOKEN_ENABLED',
+  TOKEN_SCOPE_CHANGED: 'TOKEN_SCOPE_CHANGED',
+  TOKEN_DELETED: 'TOKEN_DELETED',
+  TOKEN_VERIFY_FAILED: 'TOKEN_VERIFY_FAILED',
+};
+
+function writeAuditLog(db, entry = {}) {
+  try {
+    if (!db) return false;
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO audit_logs (event, token_id, operation, timestamp, success, client, detail)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      String(entry.event || 'UNKNOWN').slice(0, 64),
+      String(entry.tokenId || '').slice(0, 128) || null,
+      String(entry.operation || '').slice(0, 64) || null,
+      now,
+      entry.success === false ? 0 : 1,
+      String(entry.client || '').slice(0, 80) || null,
+      entry.detail == null ? null : redactSecrets(String(entry.detail)).slice(0, 500),
+    );
+    // Lazy retention pruning (cheap: indexed range delete, no job runner needed).
+    db.prepare('DELETE FROM audit_logs WHERE timestamp < ?').run(now - AUDIT_TTL_MS);
+    return true;
+  } catch (error) {
+    console.warn('Audit log write failed:', error?.message || error);
+    return false;
+  }
+}
+
+function listAuditLogs(db, { limit = 100 } = {}) {
+  try {
+    if (!db) return [];
+    const rows = db.prepare(
+      `SELECT event, token_id AS tokenId, operation, timestamp, success, client, detail
+       FROM audit_logs ORDER BY timestamp DESC LIMIT ?`
+    ).all(Math.max(1, Math.min(1000, Number(limit) || 100)));
+    return rows.map((row) => ({ ...row, success: row.success === 1 }));
+  } catch (error) {
+    console.warn('Audit log read failed:', error?.message || error);
+    return [];
+  }
+}
+
+module.exports = {
+  AUDIT_EVENTS,
+  AUDIT_TTL_MS,
+  writeAuditLog,
+  listAuditLogs,
+};

--- a/server/lib/utils/redact.js
+++ b/server/lib/utils/redact.js
@@ -1,0 +1,33 @@
+/**
+ * Secret redaction helpers (requirement #13) — Docker/CommonJS variant.
+ */
+
+const TOKEN_PATTERN = /kvault_[A-Za-z0-9_-]{6,}/g;
+const REDACTED = 'kvault_***REDACTED***';
+
+function redactSecrets(input) {
+  if (typeof input !== 'string') return input;
+  return input.replace(TOKEN_PATTERN, REDACTED);
+}
+
+function redactErrorMessage(error) {
+  if (error == null) return '';
+  const message = typeof error === 'string' ? error : String(error?.message || error);
+  return redactSecrets(message);
+}
+
+function safeLogError(error, ...rest) {
+  try {
+    console.error(redactErrorMessage(error), ...rest.map((item) => (
+      typeof item === 'string' ? redactSecrets(item) : item
+    )));
+  } catch {
+    // logging must never throw
+  }
+}
+
+module.exports = {
+  redactSecrets,
+  redactErrorMessage,
+  safeLogError,
+};

--- a/server/lib/utils/ssrf-guard.js
+++ b/server/lib/utils/ssrf-guard.js
@@ -1,0 +1,102 @@
+/**
+ * SSRF guard for remote URL imports (requirement #6) — Docker/Node variant.
+ * Unlike the Cloudflare Workers variant, Node can resolve DNS and validate
+ * every resolved IP address (including redirects).
+ */
+
+const dns = require('node:dns').promises;
+const { isPrivateHost, sniffImageMime, MAX_REDIRECTS } = require('./ssrf-shared');
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'metadata',
+  'metadata.google.internal',
+  'instance-data',
+  'instance-data.internal',
+]);
+
+function validateRemoteUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(String(rawUrl || '').trim());
+  } catch {
+    return { ok: false, code: 'INVALID_URL', message: 'Invalid URL.' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, code: 'INVALID_URL', message: 'Only http/https URLs are allowed.' };
+  }
+
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (!hostname) {
+    return { ok: false, code: 'INVALID_URL', message: 'URL has no hostname.' };
+  }
+  if (isPrivateHost(hostname)) {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Requests to private, loopback or metadata addresses are blocked.' };
+  }
+
+  const port = parsed.port ? Number(parsed.port) : (parsed.protocol === 'https:' ? 443 : 80);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    return { ok: false, code: 'INVALID_URL', message: 'Invalid port.' };
+  }
+  if (port !== 80 && port !== 443 && port !== 8080 && port !== 8443) {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Only ports 80, 443, 8080 and 8443 are allowed for remote import.' };
+  }
+
+  return { ok: true, url: parsed };
+}
+
+/**
+ * Validate URL AND resolve DNS, checking every resolved address.
+ * Redirect targets must be re-validated with this function on every hop.
+ */
+async function assertSafeRemoteUrl(rawUrl) {
+  const check = validateRemoteUrl(rawUrl);
+  if (!check.ok) return check;
+
+  const hostname = check.url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  // Pure literal IPs are already covered by isPrivateHost; resolve names.
+  if (!/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) && hostname.includes('.')) {
+    try {
+      const addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+      for (const entry of addresses) {
+        if (isPrivateHost(entry.address)) {
+          return {
+            ok: false,
+            code: 'SSRF_BLOCKED',
+            message: `Hostname resolves to a private/protected address (${entry.address}); import blocked.`,
+          };
+        }
+      }
+    } catch (error) {
+      return { ok: false, code: 'INVALID_URL', message: `DNS resolution failed: ${error?.message || 'unknown'}` };
+    }
+  }
+
+  return check;
+}
+
+function validateRedirectLocation(location, previousUrl) {
+  let next;
+  try {
+    next = new URL(String(location || ''), previousUrl);
+  } catch {
+    return { ok: false, code: 'INVALID_REDIRECT', message: 'Invalid redirect location.' };
+  }
+  if (next.protocol !== 'http:' && next.protocol !== 'https:') {
+    return { ok: false, code: 'SSRF_BLOCKED', message: 'Redirects to non-http(s) protocols are blocked.' };
+  }
+  return validateRemoteUrl(next.href);
+}
+
+module.exports = {
+  validateRemoteUrl,
+  assertSafeRemoteUrl,
+  validateRedirectLocation,
+  isPrivateHost,
+  sniffImageMime,
+  MAX_REDIRECTS,
+  BLOCKED_HOSTNAMES,
+};

--- a/server/lib/utils/ssrf-shared.js
+++ b/server/lib/utils/ssrf-shared.js
@@ -1,0 +1,97 @@
+/**
+ * Shared SSRF primitives used by the Docker/Node ssrf-guard variant.
+ * Mirrors the logic in functions/utils/ssrf-guard.js (Cloudflare Pages).
+ * The Pages variant cannot resolve DNS, so full DNS validation lives in
+ * server/lib/utils/ssrf-guard.js; the helpers below are identical on both.
+ */
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'metadata',
+  'metadata.google.internal',
+  'instance-data',
+  'instance-data.internal',
+]);
+
+function ipv4ToInt(host) {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    value = value * 256 + octet;
+  }
+  return value;
+}
+
+function isPrivateIPv4(host) {
+  const value = ipv4ToInt(host);
+  if (value == null) return false;
+  const a = (value / 256 / 256 / 256) | 0;
+  const second = (value / 256 / 256) | 0;
+  const b = second % 256;
+  if (a === 0) return true;                       // 0.0.0.0/8 "this network"
+  if (a === 10) return true;                      // RFC1918 10/8
+  if (a === 127) return true;                     // loopback
+  if (a === 169 && b === 254) return true;        // link-local + AWS/GCP metadata
+  if (a === 172 && (b >= 16 && b <= 31)) return true; // RFC1918 172.16/12
+  if (a === 192 && b === 168) return true;        // RFC1918 192.168/16
+  if (a === 100 && (b >= 64 && b <= 127)) return true; // CGNAT 100.64/10
+  if (a >= 224) return true;                      // multicast + reserved
+  return false;
+}
+
+function isPrivateIPv6(host) {
+  const value = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (value === '::' || value === '::1') return true;
+  if (value.startsWith('fe80')) return true;      // link-local
+  if (value.startsWith('fc') || value.startsWith('fd')) return true; // ULA fc00::/7
+  if (value.startsWith('fec') || value.startsWith('fed') || value.startsWith('fee') || value.startsWith('fef')) return true;
+  if (value.startsWith('fd00:ec2:')) return true; // AWS IPv6 metadata
+  if (value.startsWith('::ffff:')) {
+    const mapped = value.slice(7);
+    if (mapped.includes('.')) return isPrivateIPv4(mapped);
+  }
+  return false;
+}
+
+function isPrivateHost(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (BLOCKED_HOSTNAMES.has(host)) return true;
+  if (host.endsWith('.localhost') || host.endsWith('.local') || host.endsWith('.internal')) return true;
+  if (isPrivateIPv4(host)) return true;
+  if (host.includes(':')) return isPrivateIPv6(host);
+  return false;
+}
+
+const MAX_REDIRECTS = 5;
+
+/** Sniff image MIME from magic bytes (never trust Content-Type alone). */
+function sniffImageMime(bytes) {
+  if (!bytes || bytes.length < 12) return null;
+  const b = bytes;
+  const startsWith = (arr, offset = 0) => arr.every((byte, index) => b[offset + index] === byte);
+
+  if (startsWith([0xff, 0xd8, 0xff])) return 'image/jpeg';
+  if (startsWith([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return 'image/png';
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && startsWith([0x57, 0x45, 0x42, 0x50], 8)) return 'image/webp';
+  if (startsWith([0x66, 0x74, 0x79, 0x70], 4) && startsWith([0x61, 0x76, 0x69, 0x66], 8)) return 'image/avif';
+  if (startsWith([0x47, 0x49, 0x46, 0x38])) return 'image/gif';
+  if (startsWith([0x42, 0x4d])) return 'image/bmp';
+  if (startsWith([0x00, 0x00, 0x01, 0x00])) return 'image/x-icon';
+  return null;
+}
+
+module.exports = {
+  BLOCKED_HOSTNAMES,
+  isPrivateHost,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  MAX_REDIRECTS,
+  sniffImageMime,
+};

--- a/test/admin-security.test.js
+++ b/test/admin-security.test.js
@@ -1,0 +1,112 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const { createApp } = require('../server/app');
+
+describe('Admin API fail-closed security (Docker)', function () {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+
+  beforeEach(function () {
+    tmpDir = path.join(__dirname, '..', 'data', `tmp-admin-sec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    process.env.CONFIG_ENCRYPTION_KEY = 'admin_sec_key_123456';
+    process.env.SESSION_SECRET = 'admin_sec_secret_123456';
+    process.env.DATA_DIR = tmpDir;
+    process.env.DB_PATH = path.join(tmpDir, 'admin-sec.db');
+    process.env.BASIC_USER = '';
+    process.env.BASIC_PASS = '';
+    process.env.TG_BOT_TOKEN = '';
+    process.env.TG_CHAT_ID = '';
+    process.env.DEFAULT_STORAGE_TYPE = 'telegram';
+  });
+
+  afterEach(function () {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  const adminRoutes = [
+    ['GET', '/api/admin/tokens', null],
+    ['POST', '/api/admin/tokens', JSON.stringify({ name: 'x', scopes: ['read'] })],
+    ['PATCH', '/api/admin/tokens/some-id', JSON.stringify({ enabled: false })],
+    ['DELETE', '/api/admin/tokens/some-id', null],
+    ['POST', '/api/admin/tokens/some-id/rotate', null],
+    ['GET', '/api/admin/audit-logs', null],
+  ];
+
+  it('returns 503 ADMIN_AUTH_NOT_CONFIGURED on every admin route when auth is unconfigured', async function () {
+    const app = createApp();
+    for (const [method, url, body] of adminRoutes) {
+      const response = await app.fetch(new Request(`http://localhost${url}`, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : {},
+        body: body || undefined,
+      }));
+      const payload = await response.json();
+      assert.strictEqual(response.status, 503, `${method} ${url} -> ${response.status}`);
+      assert.strictEqual(payload.error?.code, 'ADMIN_AUTH_NOT_CONFIGURED', `${method} ${url}`);
+    }
+  });
+
+  it('returns 401 when auth is configured but credentials are missing', async function () {
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'secret123';
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/admin/tokens'));
+    assert.strictEqual(response.status, 401);
+  });
+
+  it('allows admin token management with valid basic auth credentials', async function () {
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'secret123';
+    const authHeader = `Basic ${Buffer.from('admin:secret123').toString('base64')}`;
+    const app = createApp();
+
+    const createResponse = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+      body: JSON.stringify({ name: 'ci-bot', scopes: ['upload', 'read'] }),
+    }));
+    assert.strictEqual(createResponse.status, 201);
+    const createPayload = await createResponse.json();
+    assert.ok(String(createPayload.token || '').startsWith('kvault_'));
+
+    const listResponse = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      headers: { Authorization: authHeader },
+    }));
+    assert.strictEqual(listResponse.status, 200);
+    const listPayload = await listResponse.json();
+    assert.ok(Array.isArray(listPayload.tokens));
+
+    const auditResponse = await app.fetch(new Request('http://localhost/api/admin/audit-logs', {
+      headers: { Authorization: authHeader },
+    }));
+    assert.strictEqual(auditResponse.status, 200);
+    const auditPayload = await auditResponse.json();
+    assert.ok(Array.isArray(auditPayload.logs));
+    assert.ok(auditPayload.logs.some((entry) => entry.event === 'TOKEN_CREATED'));
+  });
+
+  it('rejects bare numeric expiresAt with 400 INVALID_EXPIRY', async function () {
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'secret123';
+    const authHeader = `Basic ${Buffer.from('admin:secret123').toString('base64')}`;
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+      body: JSON.stringify({ name: 'x', scopes: ['read'], expiresAt: 1790000000000 }),
+    }));
+    const payload = await response.json();
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(payload.error?.code, 'INVALID_EXPIRY');
+  });
+});

--- a/test/api-v1.test.js
+++ b/test/api-v1.test.js
@@ -232,8 +232,10 @@ describe('API v1 middleware auth', function () {
     assert.strictEqual(response.status, 200);
     assert.strictEqual(nextCalled, true);
 
+    const stat = await env.img_url.get(`token_stat:${tokenInfo.id}`, { type: 'json' });
+    assert.ok(Number(stat?.lastUsedAt || 0) > 0);
     const tokenRecord = await env.img_url.get(`api_token:${tokenInfo.id}`, { type: 'json' });
-    assert.ok(Number(tokenRecord?.lastUsedAt || 0) > 0);
+    assert.ok(!tokenRecord || tokenRecord.lastUsedAt == null);
   });
 });
 

--- a/test/pages-ssrf-guard.test.js
+++ b/test/pages-ssrf-guard.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert');
+
+describe('Pages ssrf-guard literal-IP protection', function () {
+  let guard;
+
+  before(async function () {
+    guard = await import('../functions/utils/ssrf-guard.js');
+  });
+
+  it('blocks RFC1918 / loopback / link-local / CGNAT / unspecified literals', async function () {
+    const blocked = [
+      'http://10.1.2.3/x.jpg',
+      'http://127.0.0.1/x.jpg',
+      'http://169.254.169.254/latest/meta-data/',
+      'http://172.16.0.9/x.jpg',
+      'http://172.31.255.254/x.jpg',
+      'http://192.168.1.1/x.jpg',
+      'http://100.64.0.1/x.jpg',
+      'http://0.0.0.0/x.jpg',
+    ];
+    for (const target of blocked) {
+      const result = await guard.validateRemoteUrl(target);
+      assert.ok(!result.ok, `${target} must be blocked`);
+    }
+  });
+
+  it('allows public literal IPs without DNS dependence', async function () {
+    const result = await guard.validateRemoteUrl('http://8.8.8.8/x.jpg');
+    assert.ok(result.ok, '8.8.8.8 is public and must not be blocked');
+  });
+
+  it('rejects non-http(s) protocols', async function () {
+    const result = await guard.validateRemoteUrl('ftp://example.com/x.jpg');
+    assert.ok(!result.ok);
+  });
+
+  it('blocks private redirect targets and allows same-site relative redirects', async function () {
+    const blocked = await guard.validateRedirectLocation('http://127.0.0.1/x', 'https://example.com/a');
+    assert.ok(!blocked.ok);
+
+    const relative = await guard.validateRedirectLocation('/b', 'https://example.com/a');
+    assert.ok(relative.ok);
+  });
+});

--- a/test/server-api-v1-docker.test.js
+++ b/test/server-api-v1-docker.test.js
@@ -44,11 +44,16 @@ describe('Docker runtime API v1 parity', function () {
   }
 
   it('creates admin API tokens and uses them for paste endpoints', async function () {
+    // Requirement #1: the admin API fails closed when auth is unconfigured;
+    // this legacy parity test now authenticates like a real admin client.
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'docker-parity-pass';
+    const adminAuth = `Basic ${Buffer.from('admin:docker-parity-pass').toString('base64')}`;
     const app = createApp();
 
     const createTokenResponse = await app.fetch(new Request('http://localhost/api/admin/tokens', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Authorization: adminAuth },
       body: JSON.stringify({ name: 'smoke', scopes: ['paste', 'read', 'delete'] }),
     }));
     await expectStatus(createTokenResponse, 201);

--- a/test/token-lifecycle-security.test.js
+++ b/test/token-lifecycle-security.test.js
@@ -1,0 +1,104 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const { initDatabase } = require('../server/db');
+const { ApiTokenRepository, parseExpiryInput } = require('../server/lib/repos/api-token-repo');
+
+describe('API token lifecycle security (Docker repo)', function () {
+  let db;
+  let repo;
+
+  beforeEach(function () {
+    const tmpDir = path.join(__dirname, '..', 'data', `tmp-token-life-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    db = initDatabase(path.join(tmpDir, 'token-life.db'));
+    repo = new ApiTokenRepository(db);
+  });
+
+  function createToken(overrides = {}) {
+    return repo.create({
+      name: 'lifecycle',
+      scopes: ['upload', 'read'],
+      ...overrides,
+    });
+  }
+
+  it('creates a token whose secret verifies', function () {
+    const { token, record } = createToken();
+    assert.ok(token.startsWith('kvault_'));
+    const result = repo.verify(token, 'upload');
+    assert.ok(result.ok);
+    assert.strictEqual(result.token.id, record.id);
+  });
+
+  it('rejects disabled tokens even after usage telemetry is written', function () {
+    const { token, record } = createToken();
+    repo.touchApiTokenUsage(record.id, { success: true, operation: 'POST /api/v1/upload', client: 'test' });
+    repo.update(record.id, { enabled: false });
+    assert.ok(!repo.verify(token, 'upload').ok);
+    // telemetry must never resurrect a disabled token
+    repo.touchApiTokenUsage(record.id, { success: true, operation: 'POST /api/v1/upload', client: 'test' });
+    assert.ok(!repo.verify(token, 'upload').ok);
+  });
+
+  it('rejects expired tokens', function () {
+    const { token } = createToken({ expiresAt: Date.now() - 1000 });
+    const result = repo.verify(token, 'upload');
+    assert.ok(!result.ok);
+    assert.ok(['TOKEN_EXPIRED', 'TOKEN_INVALID'].includes(result.code));
+  });
+
+  it('denies scopes the token does not have', function () {
+    const { token } = createToken({ scopes: ['read'] });
+    const result = repo.verify(token, 'delete');
+    assert.ok(!result.ok);
+    assert.strictEqual(result.status, 403);
+  });
+
+  it('rejects invalid scopes at creation with the invalid list', function () {
+    assert.throws(() => createToken({ scopes: ['upload', 'root'] }), (error) => {
+      assert.strictEqual(error.code, 'INVALID_SCOPE');
+      assert.deepStrictEqual(error.invalidScopes, ['root']);
+      return true;
+    });
+  });
+
+  it('rejects bare numeric expiresAt (unit ambiguity)', function () {
+    // Strict parsing lives at parseExpiryInput / route layer; the repo
+    // stores already-normalized epoch-ms values.
+    assert.throws(() => parseExpiryInput(1790000000000), (error) => {
+      assert.strictEqual(error.code, 'INVALID_EXPIRY');
+      return true;
+    });
+  });
+
+  it('rotate() invalidates the old secret and issues a working new one', function () {
+    const { token, record } = createToken();
+    const rotated = repo.rotate(record.id);
+    assert.ok(rotated.token.startsWith('kvault_'));
+    assert.notStrictEqual(rotated.token, token);
+    assert.ok(!repo.verify(token, 'upload').ok);
+    assert.ok(repo.verify(rotated.token, 'upload').ok);
+    assert.ok(Number(rotated.record.rotatedAt || 0) > 0);
+  });
+
+  it('parses expiresAtMs / ISO expiresAt / null through parseExpiryInput', function () {
+    const ms = Date.now() + 3600 * 1000;
+    assert.strictEqual(parseExpiryInput({ expiresAtMs: ms }), ms);
+    assert.ok(parseExpiryInput(new Date(ms).toISOString()) > Date.now());
+    assert.strictEqual(parseExpiryInput(null), null);
+  });
+
+  it('touchApiTokenUsage feeds stats without exposing credentials', function () {
+    const { token, record } = createToken();
+    repo.touchApiTokenUsage(record.id, { success: true, operation: 'GET /api/v1/files', client: 'mocha' });
+    const stat = repo.getStat(record.id);
+    assert.ok(stat);
+    assert.ok(Number(stat.usageCount || 0) >= 1);
+    const publicRecord = repo.toPublicRecord(repo.getById(record.id), stat);
+    assert.ok(!('secret' in publicRecord));
+    assert.ok(!('tokenHash' in publicRecord));
+    assert.ok(!('salt' in publicRecord));
+    assert.ok(repo.verify(token, 'read').ok);
+  });
+});

--- a/test/v1-cors-parity.test.js
+++ b/test/v1-cors-parity.test.js
@@ -1,0 +1,84 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const { createApp } = require('../server/app');
+
+describe('API v1 CORS allow-list (Docker)', function () {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+
+  beforeEach(function () {
+    tmpDir = path.join(__dirname, '..', 'data', `tmp-cors-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    process.env.CONFIG_ENCRYPTION_KEY = 'cors_key_123456';
+    process.env.SESSION_SECRET = 'cors_secret_123456';
+    process.env.DATA_DIR = tmpDir;
+    process.env.DB_PATH = path.join(tmpDir, 'cors.db');
+    process.env.BASIC_USER = '';
+    process.env.BASIC_PASS = '';
+    process.env.TG_BOT_TOKEN = '';
+    process.env.TG_CHAT_ID = '';
+    process.env.DEFAULT_STORAGE_TYPE = 'telegram';
+    process.env.API_CORS_ORIGINS = 'https://app.example.com, https://blog.example.org/';
+  });
+
+  afterEach(function () {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  it('answers OPTIONS preflight with 204 and no ACAO for unknown origins', async function () {
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/v1/upload', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://evil.example.net',
+        'Access-Control-Request-Method': 'POST',
+      },
+    }));
+    assert.strictEqual(response.status, 204);
+    assert.strictEqual(response.headers.get('access-control-allow-origin'), null);
+    assert.ok(String(response.headers.get('vary') || '').includes('Origin'));
+  });
+
+  it('echoes allow-listed origins on preflight and permits Idempotency-Key header', async function () {
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/v1/upload', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://app.example.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Authorization, Idempotency-Key',
+      },
+    }));
+    assert.strictEqual(response.status, 204);
+    assert.strictEqual(response.headers.get('access-control-allow-origin'), 'https://app.example.com');
+    assert.strictEqual(response.headers.get('access-control-allow-credentials'), 'true');
+    assert.ok(String(response.headers.get('access-control-allow-headers') || '').includes('Idempotency-Key'));
+  });
+
+  it('normalizes trailing slashes from API_CORS_ORIGINS entries on real responses', async function () {
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/v1/capabilities', {
+      headers: { Origin: 'https://blog.example.org' },
+    }));
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get('access-control-allow-origin'), 'https://blog.example.org');
+  });
+
+  it('never adds CORS headers for non-listed origins on real responses', async function () {
+    const app = createApp();
+    const response = await app.fetch(new Request('http://localhost/api/v1/capabilities', {
+      headers: { Origin: 'https://evil.example.net' },
+    }));
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get('access-control-allow-origin'), null);
+  });
+});

--- a/test/v1-import-ssrf.test.js
+++ b/test/v1-import-ssrf.test.js
@@ -1,0 +1,145 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const { isPrivateHost } = require('../server/lib/utils/ssrf-shared');
+const { createApp } = require('../server/app');
+
+describe('SSRF shared host classification', function () {
+  const privateTargets = [
+    '10.0.0.1',
+    '10.255.255.255',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.16.0.1',
+    '172.20.1.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '100.64.0.1',
+    '100.127.255.255',
+    '0.0.0.0',
+    '::1',
+    'fe80::1',
+    'fc00::1',
+    'localhost',
+    'metadata.google.internal',
+  ];
+
+  const publicTargets = [
+    '8.8.8.8',
+    '1.1.1.1',
+    '172.32.0.1',
+    '100.128.0.1',
+    'example.com',
+  ];
+
+  for (const host of privateTargets) {
+    it(`classifies ${host} as private`, function () {
+      assert.strictEqual(isPrivateHost(host), true, host);
+    });
+  }
+
+  for (const host of publicTargets) {
+    it(`classifies ${host} as public`, function () {
+      assert.strictEqual(isPrivateHost(host), false, host);
+    });
+  }
+});
+
+describe('API v1 import SSRF protection (Docker)', function () {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+  let app;
+  let token;
+
+  beforeEach(async function () {
+    tmpDir = path.join(__dirname, '..', 'data', `tmp-import-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    process.env.CONFIG_ENCRYPTION_KEY = 'import_key_123456';
+    process.env.SESSION_SECRET = 'import_secret_123456';
+    process.env.DATA_DIR = tmpDir;
+    process.env.DB_PATH = path.join(tmpDir, 'import.db');
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'secret123';
+    process.env.TG_BOT_TOKEN = '';
+    process.env.TG_CHAT_ID = '';
+    process.env.DEFAULT_STORAGE_TYPE = 'telegram';
+    process.env.API_CORS_ORIGINS = '';
+
+    const authHeader = `Basic ${Buffer.from('admin:secret123').toString('base64')}`;
+    app = createApp();
+    const createResponse = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+      body: JSON.stringify({ name: 'import-bot', scopes: ['upload'] }),
+    }));
+    assert.strictEqual(createResponse.status, 201);
+    const payload = await createResponse.json();
+    token = payload.token;
+  });
+
+  afterEach(function () {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  const blockedUrls = [
+    'http://127.0.0.1:8080/x.jpg',
+    'http://10.1.2.3/x.jpg',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://172.16.0.9/x.jpg',
+    'http://192.168.1.1/x.jpg',
+    'http://100.64.0.1/x.jpg',
+    'http://localhost/x.jpg',
+    'http://metadata.google.internal/computeMetadata/v1/',
+  ];
+
+  for (const target of blockedUrls) {
+    it(`blocks import of ${target}`, async function () {
+      const response = await app.fetch(new Request('http://localhost/api/v1/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ url: target, storage: 'telegram' }),
+      }));
+      const payload = await response.json();
+      assert.ok(response.status === 403 || response.status === 400, `${target} -> ${response.status}`);
+      assert.ok(!payload.success);
+    });
+  }
+
+  it('rejects non-http(s) protocols', async function () {
+    const response = await app.fetch(new Request('http://localhost/api/v1/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ url: 'ftp://example.com/x.jpg', storage: 'telegram' }),
+    }));
+    assert.ok(response.status === 400 || response.status === 403);
+  });
+
+  it('requires the url field', async function () {
+    const response = await app.fetch(new Request('http://localhost/api/v1/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ storage: 'telegram' }),
+    }));
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('rejects unknown storage backends with the allowed list', async function () {
+    const response = await app.fetch(new Request('http://localhost/api/v1/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ url: 'http://localhost/x.jpg', storage: 'dropbox' }),
+    }));
+    const payload = await response.json();
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(payload.error?.code, 'INVALID_STORAGE');
+    assert.ok(Array.isArray(payload.error?.allowedStorages));
+  });
+});

--- a/test/v1-policy-idempotency.test.js
+++ b/test/v1-policy-idempotency.test.js
@@ -1,0 +1,194 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+const { createApp } = require('../server/app');
+const { initDatabase } = require('../server/db');
+const { loadConfig } = require('../server/lib/config');
+const { FileRepository } = require('../server/lib/repos/file-repo');
+const { StorageConfigRepository } = require('../server/lib/repos/storage-config-repo');
+
+describe('API v1 token policies, idempotency and dedup (Docker)', function () {
+  const originalEnv = { ...process.env };
+  let tmpDir;
+  let app;
+  let authHeader;
+
+  beforeEach(function () {
+    tmpDir = path.join(__dirname, '..', 'data', `tmp-policy-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    process.env.CONFIG_ENCRYPTION_KEY = 'policy_key_123456';
+    process.env.SESSION_SECRET = 'policy_secret_123456';
+    process.env.DATA_DIR = tmpDir;
+    process.env.DB_PATH = path.join(tmpDir, 'policy.db');
+    process.env.BASIC_USER = 'admin';
+    process.env.BASIC_PASS = 'secret123';
+    process.env.TG_BOT_TOKEN = '';
+    process.env.TG_CHAT_ID = '';
+    process.env.DEFAULT_STORAGE_TYPE = 'telegram';
+    process.env.API_CORS_ORIGINS = '';
+
+    authHeader = `Basic ${Buffer.from('admin:secret123').toString('base64')}`;
+    app = createApp();
+  });
+
+  afterEach(function () {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  async function createToken(policies) {
+    const response = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+      body: JSON.stringify({ name: 'policy-bot', scopes: ['upload'], policies }),
+    }));
+    assert.strictEqual(response.status, 201);
+    const payload = await response.json();
+    return payload.token;
+  }
+
+  function uploadRequest(token, { content = 'hello', storage = 'telegram', folderPath = '', idempotencyKey = '' } = {}) {
+    const form = new FormData();
+    form.append('file', new Blob([content], { type: 'image/png' }), 'hello.png');
+    if (storage) form.append('storage', storage);
+    if (folderPath) form.append('folderPath', folderPath);
+    const headers = { Authorization: `Bearer ${token}` };
+    if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
+    return app.fetch(new Request('http://localhost/api/v1/upload', {
+      method: 'POST',
+      headers,
+      body: form,
+    }));
+  }
+
+  it('blocks uploads to storages outside allowedStorages', async function () {
+    const token = await createToken({ allowedStorages: ['r2'] });
+    const response = await uploadRequest(token, { storage: 'telegram' });
+    const payload = await response.json();
+    assert.strictEqual(response.status, 403);
+    assert.strictEqual(payload.error?.code, 'POLICY_DENIED');
+    assert.deepStrictEqual(payload.error?.allowedStorages, ['r2']);
+  });
+
+  it('blocks uploads outside the folderPrefix policy', async function () {
+    const token = await createToken({ folderPrefix: 'agent-uploads' });
+    const response = await uploadRequest(token, { folderPath: 'other' });
+    const payload = await response.json();
+    assert.strictEqual(response.status, 403);
+    assert.strictEqual(payload.error?.code, 'POLICY_DENIED');
+  });
+
+  it('returns 413 when the file exceeds the token maxFileSize policy', async function () {
+    const token = await createToken({ maxFileSize: 2 });
+    const response = await uploadRequest(token, { content: 'toolarge' });
+    const payload = await response.json();
+    assert.strictEqual(response.status, 413);
+    assert.strictEqual(payload.error?.code, 'POLICY_FILE_TOO_LARGE');
+  });
+
+  it('rejects invalid policies at creation', async function () {
+    const response = await app.fetch(new Request('http://localhost/api/admin/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+      body: JSON.stringify({
+        name: 'bad-policy',
+        scopes: ['upload'],
+        policies: { allowedStorages: ['dropbox'] },
+      }),
+    }));
+    const payload = await response.json();
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(payload.error?.code, 'INVALID_POLICY');
+  });
+
+  it('replays the same response for a repeated Idempotency-Key', async function () {
+    const token = await createToken(null);
+    const content = 'idem-content-bytes';
+    const sha = crypto.createHash('sha256').update(Buffer.from(content, 'utf8')).digest('hex');
+
+    // Pre-seed the SHA-256 dedup index so the first upload resolves without a
+    // real storage backend (Requirement #11); the dedup response is then cached
+    // and replayed on the second request carrying the same Idempotency-Key.
+    const db = initDatabase(process.env.DB_PATH);
+    const config = loadConfig(process.env);
+    const storageRepo = new StorageConfigRepository(db, config);
+    const storage = storageRepo.create({
+      name: 'Telegram Idem',
+      type: 'telegram',
+      config: { botToken: 'token', chatId: 'chat' },
+      enabled: true,
+      isDefault: true,
+    });
+    const fileRepo = new FileRepository(db);
+    fileRepo.create({
+      id: 'idem-original.png',
+      storageConfigId: storage.id,
+      storageType: 'telegram',
+      storageKey: 'idem-original',
+      fileName: 'idem-original.png',
+      fileSize: Buffer.byteLength(content),
+      mimeType: 'image/png',
+      extra: { shareSlug: 'idem-share' },
+    });
+    db.prepare('INSERT INTO sha_dedup_index(sha256, file_id, file_name, storage_type, file_size, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .run(sha, 'idem-original.png', 'idem-original.png', 'telegram', Buffer.byteLength(content), Date.now(), Date.now() + 86400000);
+
+    const first = await uploadRequest(token, { content, idempotencyKey: 'op-1' });
+    assert.strictEqual(first.status, 200);
+    const firstPayload = await first.json();
+    assert.ok(firstPayload.success);
+    const firstFileId = firstPayload.file?.id;
+    assert.strictEqual(firstFileId, 'idem-original.png');
+
+    const second = await uploadRequest(token, { content, idempotencyKey: 'op-1' });
+    assert.strictEqual(second.status, 200);
+    assert.strictEqual(second.headers.get('idempotency-replayed'), 'true');
+    const secondPayload = await second.json();
+    assert.strictEqual(secondPayload.file?.id, firstFileId);
+  });
+
+  it('deduplicates identical small uploads through the SHA-256 index', async function () {
+    const token = await createToken(null);
+    const content = 'dedup-content-bytes';
+    const sha = crypto.createHash('sha256').update(Buffer.from(content, 'utf8')).digest('hex');
+
+    const db = initDatabase(process.env.DB_PATH);
+    const config = loadConfig(process.env);
+    const storageRepo = new StorageConfigRepository(db, config);
+    const storage = storageRepo.create({
+      name: 'Telegram Test',
+      type: 'telegram',
+      config: { botToken: 'token', chatId: 'chat' },
+      enabled: true,
+      isDefault: true,
+    });
+    const fileRepo = new FileRepository(db);
+    fileRepo.create({
+      id: 'dedup-original.png',
+      storageConfigId: storage.id,
+      storageType: 'telegram',
+      storageKey: 'dedup-original',
+      fileName: 'dedup-original.png',
+      fileSize: Buffer.byteLength(content),
+      mimeType: 'image/png',
+      extra: { shareSlug: 'dedup-share' },
+    });
+    db.prepare('INSERT INTO sha_dedup_index(sha256, file_id, file_name, storage_type, file_size, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .run(sha, 'dedup-original.png', 'dedup-original.png', 'telegram', Buffer.byteLength(content), Date.now(), Date.now() + 86400000);
+
+    const response = await uploadRequest(token, { content });
+    assert.strictEqual(response.status, 200);
+    const payload = await response.json();
+    assert.strictEqual(payload.deduplicated, true);
+    assert.strictEqual(payload.file?.id, 'dedup-original.png');
+    assert.ok(payload.links?.download);
+  });
+});


### PR DESCRIPTION
# fix(api-token): API Token 平台化重构（安全 / 策略 / 幂等 / SSRF / Agent 接入）

## 1. 原始问题

此前的 API Token 只是网页登录态的附属品，无法支撑长期稳定的机器客户端（GitHub Actions、Coze Agent、ShareX、脚本、未来 MCP Agent）：

- Token 与 Session 混用，无独立的生命周期（轮换 / 禁用 / 过期语义不完整）；
- 无 scopes 与策略，拿到 Token 即全权操作；
- 用量遥测（lastUsedAt）直接写进凭据存储，禁用状态可能被遥测写入"复活"；
- admin API 在未配置认证时行为不确定；
- 无幂等与去重，Agent 重试会产生重复文件；
- Pages（Cloudflare Workers KV）与 Docker（SQLite）两套实现行为不一致。

## 2. 安全风险（修复前）

1. **admin API fail-open**：未配置 `BASIC_USER`/`BASIC_PASS` 时可匿名调用管理接口（创建/删除 Token、读取文件元数据）。
2. **遥测写凭据**：`lastUsedAt` 与凭据同 key 存储，并发写可能覆盖 `disabled` 状态。
3. **SSRF**：URL 导入可打内网、环回、云厂商 metadata（169.254.169.254 等），且 Pages 版 `isPrivateIPv4` 存在位运算取整 bug 导致部分私网字面 IP 漏判。
4. **协议/端口不设限**：`file://`、任意端口均可作为导入目标。
5. **SVG 默认放行**：作为上传类型存在 XSS 载体风险。

## 3. 修改架构

- **repo 层**：`api-token-repo`（Docker）与 `functions/utils/api-token.js`（Pages）整体重写——Token 格式 `kvault_<id>_<secret>`，服务端只存哈希；**双 key 模型**：`api_token:<id>` 仅存凭据，`token_stat:<id>` 存遥测（lastUsedAt / usageCount / lastSuccessAt / lastFailureAt / lastOperation / lastClient），60s 防抖，禁用状态永不被遥测覆盖；`rotate()` 使旧密钥立即失效。
- **SSRF**：双实现——Pages 用主机名级规则（Workers 无法自定义 DNS），Docker 对每个 DNS 解析结果复检；共享端口白名单 80/443/8080/8443 与协议白名单 http/https；重定向逐跳重新校验。
- **审计**：结构化 `audit_logs`（180 天 TTL），admin 查询端点 `GET /api/admin/audit-logs`；错误日志经 `redact` 脱敏。
- **幂等与去重**：`idempotency_keys` 表（24h TTL，含 status_code）+ `sha_dedup_index` 表（≤25MB，90d TTL）。
- **schema**：SQLite 新增 `api_tokens` / `token_stats` / `audit_logs` / `idempotency_keys` / `sha_dedup_index`，`db/index.js` 启动时 `ensureColumn` 自动补列。
- **路由**（`server/app.js`）：admin Token CRUD + rotate + audit-logs（全部 fail-closed）；v1 新增 `/me`、`/capabilities`、`/import`、`/files`、`/file/:id`（GET 流 + DELETE）、`/file/:id/info`；upload/import 插入策略强制、幂等、去重中间逻辑。
- **UI**（admin.html）：Token 管理弹窗（修复 modal 变灰的层级问题）、轮换按钮、策略表单、用法示例块。

## 4. Pages 与 Docker 一致性（parity）

- 相同的 Token 格式、scopes 集合（upload/read/delete/paste）、策略语义与错误码；
- 相同的 v1 响应包络（`{success, ...}` / `{success:false, error:{code,message}}`）；
- SSRF 规则一致（实现层级不同：Pages 无 DNS 解析能力，按主机名规则 + 字面 IP 判定；Docker 逐 IP 复检——两端口径对齐，测试覆盖两侧）；
- CORS 白名单行为一致（`v1-cors-parity` 测试锁定）。

## 5. API 兼容性

- 现有 `/api/v1/*` 字段与 `links` 响应结构**向后兼容**，旧客户端无需改动；
- `/api/v1/upload` 新增可选 `Idempotency-Key` 头与 `deduplicated` 字段，不带新头的调用行为不变；
- 网页上传、文件直链、分享链接、7 种存储后端行为不变。

## 6. Migration

- **Docker/SQLite**：启动时 `ensureColumn` 自动补列 + 建新表，无需手工 SQL；
- **Pages/KV**：KV 无 schema，旧 `api_token:*` 记录原样有效；遥测迁移到新 `token_stat:<id>` key，旧字段忽略，缺失统计按默认值返回；
- 旧 Token 不需要重新创建；建议对存量 Token 通过 admin API 补设 policies。

## 7. Tests

**95 passing（mocha，全套绿）**。新增 6 个测试文件，3 个旧测试适配新契约（注明对应 Requirement，无删除）：

- `admin-security.test.js`：admin 全路由 fail-closed 503 / 401、裸数字 `expiresAt` 400 `INVALID_EXPIRY`（HTTP 层）；
- `token-lifecycle-security.test.js`：哈希校验、禁用不可复活、过期拒绝、scope 越权、rotate 失效、遥测隔离、`parseExpiryInput` 语义；
- `v1-cors-parity.test.js`：预检/实际响应白名单、尾斜杠归一化、`Idempotency-Key` 放行；
- `v1-import-ssrf.test.js`：环回/私网/CGNAT/metadata/非 http(s) 全拒绝、storage 白名单；
- `v1-policy-idempotency.test.js`：allowedStorages/folderPrefix/maxFileSize 强制、策略创建校验、Idempotency-Key 重放、SHA-256 去重；
- `pages-ssrf-guard.test.js`：Pages 侧字面 IP / 协议 / 重定向防护。

## 8. API_CORS_ORIGINS 配置

浏览器直连 API 的前端需要显式白名单（服务端环境变量，已写入 `.env.example` 与 README）：

```
API_CORS_ORIGINS=https://app.example.com,https://dashboard.example.com
```

- 逗号分隔，末尾斜杠自动归一化；
- 未配置时不返回任何 CORS 头（纯服务端调用不受影响）；
- 预检仅放行白名单来源，允许 `Authorization`、`Content-Type`、`Idempotency-Key`。

## 9. blog-bot Token 创建（示例）

```bash
# 管理员创建最小权限 Token：仅 upload+read，限定目录前缀
curl -X POST "https://your-kvault-domain/api/admin/tokens" \
  -u "$BASIC_USER:$BASIC_PASS" \
  -H "Content-Type: application/json" \
  -d '{"name":"blog-bot","scopes":["upload","read"],"policies":{"folderPrefix":"blog"}}'

# 响应（仅此一次返回完整密钥，妥善保存）
# {"success":true,"token":"kvault_xxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxx","tokenInfo":{...}}
```

之后 blog-bot 只需要 `KVAULT_API_TOKEN` 环境变量，不需要任何账号密码。

## 10. import 调用示例（Agent 场景）

```bash
# Agent 把远程封面图导入图床（幂等：重试不会产生重复文件）
curl -X POST "https://your-kvault-domain/api/v1/import" \
  -H "Authorization: Bearer $KVAULT_API_TOKEN" \
  -H "Content-Type: application/json" \
  -H "Idempotency-Key: agent-run-20260903-1" \
  -d '{"url":"https://cdn.example.com/cover.jpg","storage":"r2","folder":"agent"}'

# 200
# {"success":true,"data":{"file":{"id":"...","name":"cover.jpg","size":123456,
#   "mime":"image/jpeg","sha256":"...","storage":"r2"},
#   "links":{"download":"...","share":"..."},"source":{"url":"..."},"deduplicated":false}}
```

完整 7 个 MCP tools 对照（kvault_health / capabilities / token_info / upload_file / import_url / list_files / get_file）见 `docs/agent-integration.md`，机器可读定义见 `docs/openapi.yaml`。

---

**Checklist**

- [x] 不直推 main，走 PR + CI
- [x] 无真实 Token / 密钥入库，文档仅用 `$KVAULT_API_TOKEN` 占位
- [x] 测试与日志不含完整 `kvault_` Token
- [x] 全套测试绿（95 passing）
