### PR TITLE
feat: MINIMIZE_KV_WRITES 模式下 API Token 低 KV 写入（移植 #42）

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -298,7 +298,7 @@ If you are concerned about Cloudflare KV daily quota usage, you can enable:
 - `TELEGRAM_LINK_MODE=signed` (signed direct links for Telegram files only)
 - Or `MINIMIZE_KV_WRITES=true` (also affects chunked upload task write strategy)
 
-After enabling this, Telegram files still write a lightweight KV index by default (for admin list and management operations). Downloads resolve `file_id` through signed parameters, reducing KV read/write pressure.
+After enabling this, Telegram files still write a lightweight KV index by default (for admin list and management operations). Downloads resolve `file_id` through signed parameters, reducing KV read/write pressure. With `TELEGRAM_METADATA_MODE=off`, signed Telegram uploads skip the post-upload KV metadata lookup: `password`, `expires_in`, `max_downloads`, and `slug` are ignored, and the response has no delete link. With `MINIMIZE_KV_WRITES=true`, API Token validation still reads KV, but writes `lastUsedAt` only on first use and then at least one hour apart.
 
 > **Optional tradeoff:** If you want Telegram files to skip KV writes entirely, also set `TELEGRAM_METADATA_MODE=off`. In this mode, files will not appear in the admin list, and tag/allowlist/denylist/delete flows that rely on KV metadata will be unavailable.
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
 - `TELEGRAM_LINK_MODE=signed`（仅 Telegram 文件使用签名直链）
 - 或 `MINIMIZE_KV_WRITES=true`（同时影响分片上传任务写入策略）
 
-启用后，Telegram 文件默认仍会写入轻量 KV 索引（用于后台列表和管理操作），下载时通过签名参数直接解析 `file_id`，从而降低 KV 读写压力。
+启用后，Telegram 文件默认仍会写入轻量 KV 索引（用于后台列表和管理操作），下载时通过签名参数直接解析 `file_id`，从而降低 KV 读写压力。设置 `TELEGRAM_METADATA_MODE=off` 时，签名 Telegram 上传会跳过 API 上传后的 KV 元数据探测：`password`、`expires_in`、`max_downloads`、`slug` 会被忽略，响应也不提供删除链接。设置 `MINIMIZE_KV_WRITES=true` 时，API Token 鉴权仍需读取 KV，但 `lastUsedAt` 仅在首次使用及之后至少间隔一小时才写回。
 
 > **可选取舍：** 若你希望 Telegram 文件完全不写入 KV，请额外设置 `TELEGRAM_METADATA_MODE=off`。此时文件不会出现在后台列表，也无法使用依赖 KV 元数据的标签/黑白名单/删除流程。
 

--- a/functions/api/v1/_middleware.js
+++ b/functions/api/v1/_middleware.js
@@ -8,6 +8,10 @@ import { apiError } from '../../utils/api-v1.js';
 import { handleApiPreflight, resolveCorsHeaders } from '../../utils/cors.js';
 import { writeAuditLog, AUDIT_EVENTS } from '../../utils/audit.js';
 
+// Low-write mode (MINIMIZE_KV_WRITES=true): token validation still reads KV,
+// but usage stats are persisted at most once per hour.
+const MINIMIZED_USAGE_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+
 function resolveRequiredScope(request) {
   const pathname = new URL(request.url).pathname.replace(/\/+$/, '');
   const method = String(request.method || 'GET').toUpperCase();
@@ -113,7 +117,10 @@ export async function onRequest(context) {
   context.data.apiToken = verifyResult.token;
 
   // Telemetry: writes only the stat key, 60s sampled (requirement #2).
+  // Low-write mode: raise the telemetry sampling interval from 60s to 1h.
+  const minimizeKvWrites = env.MINIMIZE_KV_WRITES === 'true';
   const touchPromise = touchApiTokenUsage(verifyResult.token.id, env, {
+    minIntervalMs: minimizeKvWrites ? MINIMIZED_USAGE_UPDATE_INTERVAL_MS : 0,
     success: true,
     operation: `${request.method} ${new URL(request.url).pathname}`.slice(0, 64),
     client: clientTag(request),

--- a/functions/api/v1/upload.js
+++ b/functions/api/v1/upload.js
@@ -1,5 +1,5 @@
 import { onRequestPost as uploadInternal } from '../../upload.js';
-import { parseSignedTelegramFileId } from '../../utils/telegram.js';
+import { parseSignedTelegramFileId, shouldWriteTelegramMetadata } from '../../utils/telegram.js';
 import { checkUploadPolicy } from '../../utils/policy-enforce.js';
 import { apiError, apiSuccess, buildAbsoluteUrl, parsePositiveInt } from '../../utils/api-v1.js';
 
@@ -378,7 +378,14 @@ export async function onRequestPost(context) {
     return apiError('UPLOAD_FAILED', '上传响应中缺少文件标识。', 502);
   }
 
-  const lookup = await findRecordByFileId(env, publicId);
+  // Low-write mode: signed Telegram uploads skip the post-upload KV metadata
+  // probe entirely (password/expires_in/max_downloads/slug are ignored and
+  // no delete link is returned).
+  const signedTelegram = await parseSignedTelegramFileId(publicId, env);
+  const skipTelegramMetadata = Boolean(signedTelegram) && !shouldWriteTelegramMetadata(env);
+  const lookup = skipTelegramMetadata
+    ? null
+    : await findRecordByFileId(env, publicId);
   let metadata = lookup?.record?.metadata || {};
   if (lookup?.key) {
     try {
@@ -398,9 +405,9 @@ export async function onRequestPost(context) {
   }
 
   const canonicalId = lookup?.key || publicId;
-  const fileName = metadata.fileName || file.name || canonicalId;
-  const fileSize = Number(metadata.fileSize || file.size || 0);
-  const uploadedAtValue = Number(metadata.TimeStamp || Date.now());
+  const fileName = metadata.fileName || file.name || signedTelegram?.fileName || canonicalId;
+  const fileSize = Number(metadata.fileSize || signedTelegram?.fileSize || file.size || 0);
+  const uploadedAtValue = Number(metadata.TimeStamp || signedTelegram?.timestamp || Date.now());
   const shareSlug = lookup?.key
     ? (sanitizeSlug(metadata.shareSlug || '') || normalizedSlug)
     : '';
@@ -430,7 +437,9 @@ export async function onRequestPost(context) {
     links: {
       download: buildAbsoluteUrl(request, `/file/${encodeURIComponent(publicId)}`),
       share: buildAbsoluteUrl(request, `/s/${encodeURIComponent(shareId)}`),
-      delete: buildAbsoluteUrl(request, `/api/v1/file/${encodeURIComponent(canonicalId)}`),
+      delete: skipTelegramMetadata
+        ? null
+        : buildAbsoluteUrl(request, `/api/v1/file/${encodeURIComponent(canonicalId)}`),
     },
   });
 }
@@ -441,3 +450,4 @@ export async function onRequest(context) {
   }
   return onRequestPost(context);
 }
+

--- a/functions/utils/api-token.js
+++ b/functions/utils/api-token.js
@@ -467,9 +467,10 @@ export async function rotateApiToken(tokenId, env) {
 
 /**
  * Telemetry write (requirement #2). Writes ONLY the stat key with a 60s
- * sample debounce. Never touches the credential record.
+ * sample debounce (minIntervalMs can raise it, e.g. 1h in low-write mode).
+ * Never touches the credential record.
  */
-export async function touchApiTokenUsage(tokenId, env, { success = true, operation = '', client = '' } = {}) {
+export async function touchApiTokenUsage(tokenId, env, { success = true, operation = '', client = '', minIntervalMs = 0 } = {}) {
   try {
     ensureKvBinding(env);
     const id = sanitizeTokenId(tokenId);
@@ -478,7 +479,10 @@ export async function touchApiTokenUsage(tokenId, env, { success = true, operati
     const now = Date.now();
     const stat = (await getStat(id, env)) || {};
 
-    if (Number(stat.lastTouchAt || 0) > 0 && now - Number(stat.lastTouchAt || 0) < STAT_DEBOUNCE_MS) {
+    // Sampled write: skip inside the debounce window. Low-write mode callers
+    // may raise the effective interval (e.g. 1h with MINIMIZE_KV_WRITES=true).
+    const minInterval = Math.max(STAT_DEBOUNCE_MS, Math.max(0, Number(minIntervalMs) || 0));
+    if (Number(stat.lastTouchAt || 0) > 0 && now - Number(stat.lastTouchAt || 0) < minInterval) {
       return false; // sampled: skip write inside the debounce window
     }
 

--- a/test/api-token-low-write.test.js
+++ b/test/api-token-low-write.test.js
@@ -1,0 +1,119 @@
+const assert = require('assert');
+
+// Minimal KV double with call counters (low-write tests only need get/put).
+class MemoryKV {
+  constructor() {
+    this.store = new Map();
+    this.putCalls = 0;
+    this.getCalls = 0;
+  }
+
+  async put(key, value = '', options = {}) {
+    this.putCalls += 1;
+    this.store.set(String(key), {
+      value: String(value ?? ''),
+      metadata: options?.metadata || null,
+    });
+  }
+
+  async get(key, options = {}) {
+    this.getCalls += 1;
+    const entry = this.store.get(String(key));
+    if (!entry) return null;
+    if (options?.type === 'json') {
+      try {
+        return JSON.parse(entry.value);
+      } catch {
+        return null;
+      }
+    }
+    return entry.value;
+  }
+
+  async delete(key) {
+    this.store.delete(String(key));
+  }
+}
+
+async function invokeMiddleware(env, token) {
+  const { onRequest } = await import('../functions/api/v1/_middleware.js');
+  const request = new Request('https://example.com/api/v1/files', {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const waiters = [];
+  const response = await onRequest({
+    request,
+    env,
+    data: {},
+    next: () => new Response('ok', { status: 200 }),
+    waitUntil: (promise) => {
+      waiters.push(Promise.resolve(promise));
+    },
+  });
+  await Promise.allSettled(waiters);
+  return response;
+}
+
+async function setupScenario({ envOverrides = {}, statAgeMs = null } = {}) {
+  const { createApiToken } = await import('../functions/utils/api-token.js');
+  const env = { img_url: new MemoryKV(), ...envOverrides };
+  const created = await createApiToken({ name: 'low-write-token', scopes: ['read'] }, env);
+  if (statAgeMs != null) {
+    await env.img_url.put(`token_stat:${created.record.id}`, JSON.stringify({
+      lastUsedAt: Date.now() - statAgeMs,
+      usageCount: 3,
+      lastTouchAt: Date.now() - statAgeMs,
+    }));
+  }
+  return { env, token: created.token, record: created.record };
+}
+
+describe('API token low-write mode (MINIMIZE_KV_WRITES=true)', function () {
+  it('still writes usage on first use when no stat record exists', async function () {
+    const { env, token } = await setupScenario({ envOverrides: { MINIMIZE_KV_WRITES: 'true' } });
+
+    const writesBefore = env.img_url.putCalls;
+    const response = await invokeMiddleware(env, token);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(env.img_url.putCalls, writesBefore + 1, 'first use must persist the usage stat');
+  });
+
+  it('skips the usage write inside the one-hour window when MINIMIZE_KV_WRITES=true', async function () {
+    const { env, token } = await setupScenario({
+      envOverrides: { MINIMIZE_KV_WRITES: 'true' },
+      statAgeMs: 90 * 1000, // 90s ago: past the default 60s debounce, inside the 1h window
+    });
+
+    const writesBefore = env.img_url.putCalls;
+    const response = await invokeMiddleware(env, token);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(env.img_url.putCalls, writesBefore, 'low-write mode must not persist usage within one hour');
+  });
+
+  it('still writes usage in default mode once the 60s debounce window has passed', async function () {
+    const { env, token } = await setupScenario({ statAgeMs: 90 * 1000 });
+
+    const writesBefore = env.img_url.putCalls;
+    const response = await invokeMiddleware(env, token);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(env.img_url.putCalls, writesBefore + 1, 'default mode keeps the 60s sampling behaviour');
+  });
+
+  it('writes usage again in low-write mode after one hour has elapsed', async function () {
+    const { env, token } = await setupScenario({
+      envOverrides: { MINIMIZE_KV_WRITES: 'true' },
+      statAgeMs: 2 * 60 * 60 * 1000, // 2h ago: outside the 1h window
+    });
+
+    const writesBefore = env.img_url.putCalls;
+    const response = await invokeMiddleware(env, token);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(env.img_url.putCalls, writesBefore + 1, 'usage must be persisted once the hourly window elapses');
+  });
+});

--- a/test/api-v1.test.js
+++ b/test/api-v1.test.js
@@ -3,9 +3,12 @@ const assert = require('assert');
 class MemoryKV {
   constructor() {
     this.store = new Map();
+    this.putCalls = 0;
+    this.getWithMetadataCalls = 0;
   }
 
   async put(key, value = '', options = {}) {
+    this.putCalls += 1;
     this.store.set(String(key), {
       value: String(value ?? ''),
       metadata: options?.metadata || null,
@@ -50,6 +53,7 @@ class MemoryKV {
   }
 
   async getWithMetadata(key) {
+    this.getWithMetadataCalls += 1;
     const entry = this.store.get(String(key));
     if (!entry) return null;
     return {
@@ -367,5 +371,97 @@ describe('API v1 file share limits', function () {
 
     const body = new Uint8Array(await response.arrayBuffer());
     assert.deepStrictEqual(Array.from(body), [2, 3]);
+  });
+});
+
+
+describe('API v1 upload low-KV-write mode', function () {
+  function createLowWriteEnv() {
+    return {
+      img_url: new MemoryKV(),
+      R2_BUCKET: new MemoryR2(),
+      TG_Bot_Token: 'test-bot-token',
+      TG_Chat_ID: '-1001234567890',
+      FILE_URL_SECRET: 'test-file-url-secret',
+      MINIMIZE_KV_WRITES: 'true',
+      TELEGRAM_METADATA_MODE: 'off',
+      TG_UPLOAD_NOTIFY: 'false',
+      disable_telemetry: 'true',
+    };
+  }
+
+  function mockTelegramFetch() {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      assert.match(String(url), /\/sendDocument$/);
+      return new Response(JSON.stringify({
+        ok: true,
+        result: { message_id: 42, document: { file_id: 'telegram-image-file-id' } },
+      }), { headers: { 'Content-Type': 'application/json' } });
+    };
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }
+
+  it('uploads signed Telegram files without metadata KV access when metadata is disabled', async function () {
+    const { onRequestPost: upload } = await import('../functions/api/v1/upload.js');
+    const env = createLowWriteEnv();
+
+    const formData = new FormData();
+    formData.append('file', new Blob(['image-bytes'], { type: 'image/png' }), 'image.png');
+
+    const restoreFetch = mockTelegramFetch();
+    try {
+      const readsBefore = env.img_url.getWithMetadataCalls;
+      const writesBefore = env.img_url.putCalls;
+      const response = await upload({
+        request: new Request('https://example.com/api/v1/upload', { method: 'POST', body: formData }),
+        env,
+        data: { apiToken: { id: 'test-token' } },
+        next: () => new Response('next', { status: 200 }),
+      });
+      const payload = await parseJson(response);
+
+      assert.strictEqual(response.status, 200);
+      assert.match(payload.links.download, /\/file\/tgs_/);
+      assert.strictEqual(payload.links.delete, null);
+      assert.strictEqual(env.img_url.getWithMetadataCalls, readsBefore, 'post-upload metadata lookup must be skipped');
+      assert.strictEqual(env.img_url.putCalls, writesBefore, 'no KV writes are expected without dedup/idempotency');
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it('ignores Telegram sharing options when metadata is disabled', async function () {
+    const { onRequestPost: upload } = await import('../functions/api/v1/upload.js');
+    const env = createLowWriteEnv();
+
+    const formData = new FormData();
+    formData.append('file', new Blob(['image-bytes'], { type: 'image/png' }), 'image.png');
+    formData.append('password', 'secret');
+    formData.append('expires_in', '86400');
+    formData.append('max_downloads', '3');
+    formData.append('slug', 'ignored-share-link');
+
+    const restoreFetch = mockTelegramFetch();
+    try {
+      const readsBefore = env.img_url.getWithMetadataCalls;
+      const writesBefore = env.img_url.putCalls;
+      const response = await upload({
+        request: new Request('https://example.com/api/v1/upload', { method: 'POST', body: formData }),
+        env,
+        data: { apiToken: { id: 'test-token' } },
+        next: () => new Response('next', { status: 200 }),
+      });
+      const payload = await parseJson(response);
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(payload.links.delete, null);
+      assert.strictEqual(env.img_url.getWithMetadataCalls, readsBefore, 'metadata lookup must be skipped');
+      assert.strictEqual(env.img_url.putCalls, writesBefore, 'sharing options must not trigger KV writes');
+    } finally {
+      restoreFetch();
+    }
   });
 });


### PR DESCRIPTION
## 变更内容

移植 #42 的低 KV 写入能力，并适配 PR #45 重构后的 API Token 架构（原 PR 基于旧架构且已产生冲突，无法直接合并）。

- MINIMIZE_KV_WRITES=true 时，API Token 鉴权仍每次读 KV 验证，但 lastUsedAt 遥测仅在首次使用及之后至少间隔一小时写回：touchApiTokenUsage 新增 minIntervalMs 参数（默认保持 60s 采样），低写模式下由中间件传入 1h
- TELEGRAM_METADATA_MODE=off 时，v1/upload 签名 Telegram 上传跳过上传后的 KV 元数据探测（findRecordByFileId + applyApiUploadMetadata），忽略 password/expires_in/max_downloads/slug，响应不提供删除链接，文件信息回退使用签名载荷内的元数据
- 新增 test/api-token-low-write.test.js：4 个用例覆盖首次写入 / 1h 窗口内跳过 / 默认 60s 采样不回归 / 1h 后恢复写入
- test/api-v1.test.js 新增 MemoryKV 调用计数器与 2 个上传跳过用例（移植自 #42，适配新架构断言语义）
- README.md / README-EN.md 补充低 KV 写入模式行为说明

Closes #42 （等效能力已适配进本 PR，感谢 @JupiterFeng 的方案与实现）